### PR TITLE
Add `Conversation->changeSubject()` and `conversation.subject_changed` action

### DIFF
--- a/app/Conversation.php
+++ b/app/Conversation.php
@@ -1767,6 +1767,16 @@ class Conversation extends Model
         return $viewers;
     }
 
+    public function changeSubject($new_subject, $user = null)
+    {
+        $prev_subject = $this->subject;
+
+        $this->subject = $new_subject;
+        $this->save();
+
+        \Eventy::action('conversation.subject_changed', $this, $user, $prev_subject);
+    }
+
     public function changeState($new_state, $user = null)
     {
         if (!array_key_exists($new_state, self::$states)) {

--- a/app/Http/Controllers/ConversationsController.php
+++ b/app/Http/Controllers/ConversationsController.php
@@ -2315,8 +2315,7 @@ class ConversationsController extends Controller
                 $subject = trim($subject);
 
                 if (!$response['msg'] && $subject) {
-                    $conversation->subject = $subject;
-                    $conversation->save();
+                    $conversation->changeSubject($subject, $user);
 
                     $response['status'] = 'success';
                 }


### PR DESCRIPTION
This PR introduces an event for when the subject of a conversation is changed. It works in a similar fashion to when e.g. the status of a conversation is modified.

Closes #4127 (my original issue).