### PR TITLE
Improve message id query to find original message

### DIFF
--- a/app/Misc/Mail.php
+++ b/app/Misc/Mail.php
@@ -801,7 +801,7 @@ class Mail
                 }
                 // Message-ID: <123@123.com>
                 $query = $folder->query()
-                    ->whereMessageId('"<'.$message_id .'>"')
+                    ->whereMessageId('"<'.addcslashes($message_id, '\"').'>"')
                     ->leaveUnread()
                     ->limit(1);
 

--- a/app/Misc/Mail.php
+++ b/app/Misc/Mail.php
@@ -801,7 +801,7 @@ class Mail
                 }
                 // Message-ID: <123@123.com>
                 $query = $folder->query()
-                    ->text('<'.$message_id.'>')
+                    ->whereMessageId('<'.$message_id.'>')
                     ->leaveUnread()
                     ->limit(1);
 

--- a/app/Misc/Mail.php
+++ b/app/Misc/Mail.php
@@ -801,7 +801,7 @@ class Mail
                 }
                 // Message-ID: <123@123.com>
                 $query = $folder->query()
-                    ->whereMessageId('<'.$message_id.'>')
+                    ->whereMessageId('"<'.$message_id .'>"')
                     ->leaveUnread()
                     ->limit(1);
 

--- a/app/Misc/Mail.php
+++ b/app/Misc/Mail.php
@@ -826,7 +826,7 @@ class Mail
                 if ($last_error && stristr($last_error, 'The specified charset is not supported')) {
                     // Solution for MS mailboxes.
                     // https://github.com/freescout-helpdesk/freescout/issues/176
-                    $query = $folder->query()->text('<'.$message_id.'>')->leaveUnread()->limit(1)->setCharset(null);
+                    $query = $folder->query()->whereMessageId('"<'.addcslashes($message_id, '\"').'>"')->leaveUnread()->limit(1)->setCharset(null);
                     if ($message_date) {
                        $query->since($message_date->subDays(7));
                        $query->before($message_date->addDays(14));


### PR DESCRIPTION
To show the original message the message id is currently being searched in the header and the body, but the specific field in the header would be sufficient.

This merge request changes the imap search query from

`UID SEARCH TEXT "<be5cd68e-ca86-4416-8c25-fb8f26d53c3e@example.com>"`

to

`UID SEARCH HEADER Message-ID "<be5cd68e-ca86-4416-8c25-fb8f26d53c3e@example.com>"`

In addition, backslash and double quotes are escaped in the message id.

Source: https://www.rfc-editor.org/rfc/rfc3501

> TEXT <string>
>          Messages that contain the specified string in the header or
>          body of the message.
> ...
> HEADER <field-name> <string>
>          Messages that have a header with the specified field-name (as
>          defined in [[RFC-2822](https://www.rfc-editor.org/rfc/rfc2822)]) and that contains the specified string
>          in the text of the header (what comes after the colon).  If the
>          string to search is zero-length, this matches all messages that
>          have a header line with the specified field-name regardless of
>          the contents.