### PR TITLE
Enhanced Email Template with Agent Avatar and Improved Layout like Zendesk

### DIFF
--- a/resources/views/emails/customer/reply_fancy.blade.php
+++ b/resources/views/emails/customer/reply_fancy.blade.php
@@ -5,74 +5,54 @@
     <style>
         p { margin:0 0 1.6em 0; }
         pre { font-family: Menlo, Monaco, monospace, sans-serif; padding: 0 0 1.6em 0; color:#333333; line-height:15px; }
-        img { max-width:100%; }
+        img { max-width:100%; border-radius: 50%; }
         a { color: #346CC4; text-decoration:none; }
+        .email-container { width: 100%!important; margin: 0; padding: 0; font-family: Arial, 'Helvetica Neue', Helvetica, Tahoma, sans-serif; }
+        .header { display: flex; align-items: center; padding: 10px 0; }
+        .avatar { width: 40px; height: 40px; margin-right: 10px; }
+        .agent-info { color: #727272; font-size: 15px; line-height: 21px; }
+        .agent-name { color: #000000; font-weight: bold; }
+        .content { color: #232323; font-size: 13px; line-height: 19px; padding: 8px 0 10px 0; }
+        .footer { color: #aaaaaa; font-size: 12px; line-height: 18px; margin-top: 30px; }
     </style>
 </head>
-<body style="-webkit-text-size-adjust:none;">@php $reply_separator = \MailHelper::getHashedReplySeparator($headers['Message-ID']); @endphp
-	<div id="{{ $reply_separator }}" class="{{ $reply_separator }}" data-fs="{{ $reply_separator }}" style="width:100%!important; margin:0; padding:0">
-	    @php
-	    	$is_forwarded = !empty($threads[0]) ? $threads[0]->isForwarded() : false;
-	    @endphp
-		@foreach ($threads as $thread)
-			@if ($loop->index == 1)<!-- originalMessage --><div class="gmail_quote" style="height:0; font-size:0px; line-height:0px; color:#ffffff;"></div>@endif
-	        <div style="width:100%; margin:0;">
-	        	@if (!$loop->first)
-                	<table width="100%" border="0" cellspacing="0" cellpadding="0" style="margin:0;">
-						<tr>
-			                <td style="padding:8px 0 10px 0;">
-			                	
-			                    <h3 style="font-family:Arial, 'Helvetica Neue', Helvetica, Tahoma, sans-serif; color:#727272; font-size:15px; line-height:21px; margin:0; font-weight:normal;">
-			                    	<strong style="color:#000000;">{{ $thread->getFromName($mailbox) }}@if ($is_forwarded && $thread->from) &lt;{{ $thread->from }}&gt;@endif</strong>
-			                    	{{--if ($loop->last){!! __(':person sent a message', ['person' => '<strong style="color:#000000;">'.htmlspecialchars($thread->getFromName($mailbox)).'</strong>']) !!}@else {!! __(':person replied', ['person' => '<strong style="color:#000000;">'.htmlspecialchars($thread->getFromName($mailbox)).'</strong>']) !!}@endif--}}
-			                	</h3>
-
-			                    @if ($thread->getCcArray())
-				                    <p style="font-family:Arial, 'Helvetica Neue', Helvetica, Tahoma, sans-serif; color:#9F9F9F; font-size:12px; line-height:16px; margin:0;">
-				                    	Cc: {{ implode(', ', $thread->getCcArray() )}}
-				                    	<br>
-				                    </p>
-				                @endif
-			                </td>
-			                <td style="padding:8px 0 10px 0;" valign="top">
-			                    <div style="font-family: Arial, 'Helvetica Neue', Helvetica, Tahoma, sans-serif; color:#9F9F9F; font-size:12px; line-height:18px; margin:0;" align="right">{{ App\Customer::dateFormat($thread->created_at, 'M j, H:i') }}</div>
-			                </td>
-			            </tr>
-			        </table>
-		        @endif
-		    </div>
-            <div colspan="2" style="padding:8px 0 10px 0;">
-                <div>
-                    <div style="font-family:Arial, 'Helvetica Neue', Helvetica, Tahoma, sans-serif; color: #232323; font-size:13px; line-height:19px; margin:0;">
-                    	@if ($thread->source_via == App\Thread::PERSON_USER && $mailbox->before_reply && $loop->first)
-                            <span style="color:#b5b5b5">{{ $mailbox->before_reply }}</span><br><br>
-                        @endif
-                        {!! $thread->body !!}
-
-                        @action('reply_email.before_signature', $thread, $loop, $threads, $conversation, $mailbox, $threads_count)
-                        @if ($thread->source_via == App\Thread::PERSON_USER && \Eventy::filter('reply_email.include_signature', true, $thread))
-                            <br>{!! $conversation->getSignatureProcessed(['thread' => $thread]) !!}
-                        @endif
-                        @action('reply_email.after_signature', $thread, $loop, $threads, $conversation, $mailbox, $threads_count)
-                        <br><br>
-                    </div>
+<body style="-webkit-text-size-adjust:none;">
+    <div class="email-container">
+        @php $reply_separator = \MailHelper::getHashedReplySeparator($headers['Message-ID']); @endphp
+        <div id="{{ $reply_separator }}" class="{{ $reply_separator }}" data-fs="{{ $reply_separator }}">
+            @foreach ($threads as $thread)
+                <div style="width:100%; margin:0;">
+                    @if (!$loop->first)
+                        <div class="header">
+                            <img class="avatar" src="{{ $thread->user()->getPhotoUrl() }}" alt="Agent Avatar">
+                            <div class="agent-info">
+                                <span class="agent-name">{{ $thread->getFromName($mailbox) }}</span>
+                                <div>{{ App\Customer::dateFormat($thread->created_at, 'M j, H:i') }}</div>
+                            </div>
+                        </div>
+                    @endif
                 </div>
-            </div>{{--@if ($loop->count > 1 && $loop->last)</blockquote>@endif--}}
-
-			<div style="height:1px"><div style="border-bottom:1px solid #e7e7e7;"></div></div>
-			<div style="height:15px;"></div>
-		@endforeach
-		@if (\App\Option::get('email_branding'))
-            <div height="" style="height:30px; font-size:12px; line-height:18px; font-family:Arial,'Helvetica Neue',Helvetica,Tahoma,sans-serif; color: #aaaaaa;">
-				{!! __('Support powered by :app_name — Free open source help desk & shared mailbox', ['app_name' => '<a href="https://landing.freescout.net">'.\Config::get('app.name').'</a>']) !!}
-			</div>
-		@endif
-		<div style="height:0; font-size:0px; line-height:0px; color:#ffffff;">	                    	
-			@if (\App\Option::get('open_tracking'))
-				<img src="{{ route('open_tracking.set_read', ['conversation_id' => $threads->first()->conversation_id, 'thread_id' => $threads->first()->id, 'otr' => '1']) }}" alt="" />
-			@endif
-			<span style="font-size: 0px; line-height: 0px; color:#ffffff !important;">{{-- Extra symbols not to show message marker in Gmail snippet preview --}} &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj; &zwnj;{{-- In addition to Message-ID header to detect relies --}}{{ \MailHelper::getMessageMarker($headers['Message-ID']) }}</span>
-		</div>
-	</div>
+                <div class="content">
+                    @if ($thread->source_via == App\Thread::PERSON_USER && $mailbox->before_reply && $loop->first)
+                        <span style="color:#b5b5b5">{{ $mailbox->before_reply }}</span><br><br>
+                    @endif
+                    {!! $thread->body !!}
+                </div>
+                @action('reply_email.before_signature', $thread, $loop, $threads, $conversation, $mailbox, $threads_count)
+                @if ($thread->source_via == App\Thread::PERSON_USER && \Eventy::filter('reply_email.include_signature', true, $thread))
+                    <br>{!! $conversation->getSignatureProcessed(['thread' => $thread]) !!}
+                @endif
+                @action('reply_email.after_signature', $thread, $loop, $threads, $conversation, $mailbox, $threads_count)
+                <br><br>
+                <div style="border-bottom:1px solid #e7e7e7;"></div>
+                <div style="height:15px;"></div>
+            @endforeach
+            @if (\App\Option::get('email_branding'))
+                <div class="footer">
+                    {!! __('Support powered by :app_name — Free open source help desk & shared mailbox', ['app_name' => '<a href="https://landing.freescout.net">'.\Config::get('app.name').'</a>']) !!}
+                </div>
+            @endif
+        </div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
<img width="1123" alt="zendesk" src="https://github.com/user-attachments/assets/0ea42a59-37d1-4944-9c10-82d85a352074">

This pull request updates the default email template for FreeScout to enhance the user experience by adding agent details, similar to Zendesk. The changes include:

- Display of the agent's avatar alongside each email thread for easy identification.
- Improved design with a flexible header section that contains the agent's name, avatar, and email timestamp.
- Refactored layout to provide a more professional look, enhancing readability and branding.

These improvements aim to make the emails sent from FreeScout more visually appealing and informative for end-users.

**Key Changes**:
1. Added agent avatar display.
2. Improved header layout for better presentation of agent details.
3. Updated CSS styles for enhanced visual consistency.

This is only for email body, and here is the signature as well

```
<div class="signature-container" style="font-family: Arial, 'Helvetica Neue', Helvetica, Tahoma, sans-serif; color: #232323; font-size: 13px; line-height: 19px; padding-top: 15px;">
    <strong style="font-weight: bold;">{%user.fullName%}</strong><br>
    <span style="color: #727272;">{%user.jobTitle%}</span><br>
    <a href="mailto:{%user.email%}" style="color: #346CC4; text-decoration: none;">{%user.email%}</a> | {%user.phone%}
</div>
```

Please review and let me know if any additional changes are required.