### PR TITLE
Fixes @fwd forwarding when styles are in HTML #4333

### DIFF
--- a/app/Console/Commands/FetchEmails.php
+++ b/app/Console/Commands/FetchEmails.php
@@ -729,7 +729,9 @@ class FetchEmails extends Command
                 && !$user_id && !$is_reply && !$prev_thread
                 // Only if the email has been sent to one mailbox.
                 && count($to) == 1 && count($cc) == 0
-                && preg_match("/^[\s]*".self::FWD_AS_CUSTOMER_COMMAND."/su", strtolower(trim(strip_tags($body))))
+                // We need to replace any potential <style></style> tags, as these will not be stripped
+                // by strip_tags https://github.com/freescout-help-desk/freescout/issues/4333
+                && preg_match("/^[\s]*".self::FWD_AS_CUSTOMER_COMMAND."/su", strtolower(trim(strip_tags(preg_replace('/<style.*?<\/style>/is', '', $body))))))
             ) {
                 // Try to get "From:" from body.
                 $original_sender = $this->getOriginalSenderFromFwd($body);


### PR DESCRIPTION
Originally, emails are only stripped of HTML tags using `strip_tags`, whilst this is right, the built in function does NOT account for `<style></style>` bodies.

Given a HTML body that starts with:

```html
<style type="text/css" style="display:none;"> P {margin-top:0;margin-bottom:0;} </style><p>@fwd</p>
```

The previous code:

```php
strtolower(trim(strip_tags($body)))
```

would output: 

```html
 P {margin-top:0;margin-bottom:0;} @fwd
```

Leaving the downstream code unable to see `@fwd`.

This pull request further strips HTML by using `preg_replace`, replace `<style>*</style>` from the aforementioned HTML, outputting the correct:

```
@fwd
```