### PR TITLE
Added filter so user can override default conversation sorting

### DIFF
--- a/app/Conversation.php
+++ b/app/Conversation.php
@@ -2221,6 +2221,8 @@ class Conversation extends Model
             'order' => 'desc',
         ];
 
+        $result = \Eventy::filter('conversations.default.sorting', $result);
+
         if (
             !empty($request->sorting['sort_by']) && !empty($request->sorting['order']) &&
             in_array($request->sorting['sort_by'], ['subject', 'number', 'date']) &&


### PR DESCRIPTION
## Description
Added filter so user can override default conversation sorting. Currently there was no way to change the default sorting.

If anyone wants to override the sorting, they can simply use:

```
Eventy::addFilter('conversations.default.sorting', function() {
  $result = [
     'sort_by' => 'date|subject|number',
     'order' => 'desc|asc'
  ];
  return $result;
}, 20, 1);
```

You can use sort_by as `date` OR `subject` OR `number` And the Sorting order can be `desc` or `asc`;