### PR TITLE
Optimize UpdateFolderCounters Job

### DIFF
--- a/app/Folder.php
+++ b/app/Folder.php
@@ -224,7 +224,9 @@ class Folder extends Model
     public function updateCounters()
     {
         if (config('app.update_folder_counters_in_background')) {
-            \App\Jobs\UpdateFolderCounters::dispatch($this);
+            if(!\Illuminate\Support\Facades\Cache::has("folder_update_lock_{$this->id}")) {
+                \App\Jobs\UpdateFolderCounters::dispatch($this);
+            }
         } else {
             $this->updateCountersNow();
         }

--- a/app/Jobs/UpdateFolderCounters.php
+++ b/app/Jobs/UpdateFolderCounters.php
@@ -2,9 +2,8 @@
 
 namespace App\Jobs;
 
-use App\Conversation;
-use App\ConversationFolder;
 use App\Folder;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Bus\Queueable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
@@ -15,28 +14,33 @@ class UpdateFolderCounters implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    /**
-     * @var Folder
-     */
     private $folder;
 
-    /**
-     * Create a new job instance.
-     *
-     * @return void
-     */
+    // Cache lock key
+    private $lockKey;
+
     public function __construct(Folder $folder)
     {
         $this->folder = $folder;
+        $this->lockKey = "folder_update_lock_{$folder->id}";
     }
 
-    /**
-     * Execute the job.
-     *
-     * @return void
-     */
     public function handle()
     {
-        $this->folder->updateCountersNow();
+        // Check if another job is processing this folder
+        if (Cache::has($this->lockKey)) {
+            return; // Exit if already processing
+        }
+
+        // Set lock with a timeout of 5 minutes (adjust as needed)
+        Cache::put($this->lockKey, true, now()->addMinutes(5));
+
+        try {
+            // Perform the folder update logic
+            $this->folder->updateCountersNow();
+        } finally {
+            // Release the lock after processing
+            Cache::forget($this->lockKey);
+        }
     }
 }


### PR DESCRIPTION
## Problem:
In cases where a mailbox is very active and has numerous custom folders, a high number of jobs are dispatched to update folder counts. Additionally, multiple duplicate jobs are being dispatched for the same folder, leading to unnecessary load on the system.

## Solution:
A locking mechanism has been implemented to ensure that if an `UpdateFolderCounters` job for a folder already exists, no duplicate jobs are dispatched for the same folder ID.

## Result:
This change has significantly reduced the load on the queue system and is functioning smoothly.