### PR TITLE
Request to add a filter and action into freescout

### DIFF
--- a/app/Console/Commands/FetchEmails.php
+++ b/app/Console/Commands/FetchEmails.php
@@ -1618,7 +1618,8 @@ class FetchEmails extends Command
 
     public function setSeen($message, $mailbox)
     {
-        $message->setFlag(['Seen']);
+        $flag = \Eventy::filter('fetch_emails.set_seen_flag', ['Seen'], $message, $mailbox);
+        $message->setFlag($flag);
         \Eventy::action('fetch_emails.after_set_seen', $message, $mailbox, $this);
     }
 }

--- a/app/Listeners/LogFailedLogin.php
+++ b/app/Listeners/LogFailedLogin.php
@@ -25,6 +25,8 @@ class LogFailedLogin
      */
     public function handle(Failed $event)
     {
+        \Eventy::action('listeners.failed_login', $event);
+
         activity()
            //->causedBy($event->user)
            ->withProperties(['ip' => app('request')->ip(), 'email' => request()->email])


### PR DESCRIPTION
I use two custom filters/actions for some custom modules I have developed for my instance of freescout.

Requesting that they be added to the codebase for ease of updates, and also so they can be used by other module developers.

**Email seen/unseen filter:**
Adds a filter to the flag that sets an email as seen on the IMAP server. Enables customisation of this behaviour.

**Failed login action:**
Emits an action when login fails, which can be used to hook into firewall software e.g. fail2ban for enhanced security.

This PR has been working fine on my installation for 2+ years.

Thank you - please let me know if you have further questions.