### PR TITLE
Allow to enable persistent connections for MySQL and PostgreSQL

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -55,6 +55,7 @@ return [
             'options'     => extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('DB_MYSQL_ATTR_SSL_CA'),
                 PDO::MYSQL_ATTR_SSL_CERT => env('DB_MYSQL_ATTR_SSL_CERT'),
+                PDO::ATTR_PERSISTENT => env('DB_ATTR_PERSISTENT'),
             ]) : [],
         ],
 
@@ -100,6 +101,7 @@ return [
             'sslmode'  => env('DB_PGSQL_SSLMODE', 'prefer'),
             'options'  => extension_loaded('pdo_pgsql') ? array_filter([
                 PDO::PGSQL_ATTR_DISABLE_PREPARES => env('DB_PGSQL_ATTR_DISABLE_PREPARES'),
+                PDO::ATTR_PERSISTENT => env('DB_ATTR_PERSISTENT'),
             ]) : [],
         ],
 


### PR DESCRIPTION
This change adds the environment variable `DB_ATTR_PERSISTENT` to request a persistent db connection instead of creating a new connection for every request. This can be useful if opening a database connection is slow, e.g. if the db is on a different host and TLS is enabled.

Persistent connection are supported by MySQL and PostgreSQL PDO driver, but I only tested PostgreSQL and had no issues so far.
The sqlsrv driver does not support it, therefore I left it out: https://github.com/Microsoft/msphpsql/issues/65

The used doctrine version does not support persistent connections, but laravel 5 implemented a workaround:
https://github.com/laravel/framework/pull/16702

Reference:
https://www.php.net/manual/en/pdo.constants.php#pdo.constants.attr-persistent