### PR TITLE
Fix handling of split boundary in email headers (RFC 2231)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ Thumbs.db
 /resources/lang/module.*
 .phpunit.result.cache
 /.phpunit.cache
+.vs/


### PR DESCRIPTION
Fixes issue #4567 where emails with split boundary definitions cause parsing errors in the Webklex/php-imap library. Results in messages not loading correctly leading to exceptions like: 

`freescout/overrides/webklex/php-imap/src/Query/Query.php  
Line 323: throw new GetMessagesFailedException($e->getMessage(), 0, $e);
`
and 
`freescout/overrides/webklex/php-imap/src/Structure.php  
Line 198: throw new MessageContentFetchingException("no content found", 0);
`

Some mail clients split long MIME boundaries into multiple parts, making them difficult to extract. This fix ensures proper email rendering. 

Introduced a method `getSplitBoundary()` to handle RFC 2231-encoded boundaries. 
It identifies multi part boundary definitions, sorts and then reconstructs them into a single boundary string. 

Integrated `getSplitBoundary()` into `getBoundary`, making sure there's fallback handling if the standard boundary extraction fails.