### PR TITLE
Fix IMAP folders retrieval selector quotes

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -747,7 +747,7 @@ function mailboxConnectionIncomingInit()
 					if (typeof(response.folders) != "undefined" && response.folders.length) {
 						for (i in response.folders) {
 							var imap_folder = response.folders[i];
-							if (select.find("option[value='"+imap_folder+"']").length) {
+							if (select.find('option[value="'+imap_folder+'"]').length) {
 								continue;
 							}
 							options_html += '<option value="'+imap_folder+'" selected="selected">'+imap_folder+'</option>'


### PR DESCRIPTION
This is a fix for issue #4682, where IMAP folders names containing single quotes (for instance "Boîte d'envoi" in french) cause a syntax error.