### PR TITLE
fix: it is "Cloudflare", not "CloudFlare"

### DIFF
--- a/.github/ISSUE_TEMPLATE/general_help_request.md
+++ b/.github/ISSUE_TEMPLATE/general_help_request.md
@@ -21,5 +21,5 @@ Still here? Well clean this out and go ahead :)
 PHP version: 
 FreeScout version: 
 Database: MySQL / PostgreSQL
-Are you using CloudFlare: Yes / No
+Are you using Cloudflare: Yes / No
 Are you using non-official modules: Yes / No

--- a/app/Misc/Helper.php
+++ b/app/Misc/Helper.php
@@ -2083,8 +2083,8 @@ class Helper
      */
     public static function getClientIp()
     {
-        // Fix for CloudFlare: https://laracasts.com/discuss/channels/laravel/cloudflare-and-user-ip
-        // But if CloudFlare is not used any value can be set to "Cf-Connecting-Ip" header.
+        // Fix for Cloudflare: https://laracasts.com/discuss/channels/laravel/cloudflare-and-user-ip
+        // But if Cloudflare is not used any value can be set to "Cf-Connecting-Ip" header.
         // if (isset($_SERVER["HTTP_CF_CONNECTING_IP"])) {
         //     $_SERVER['REMOTE_ADDR'] = $_SERVER["HTTP_CF_CONNECTING_IP"];
         // }
@@ -2190,7 +2190,7 @@ class Helper
         }
     }
 
-    public static function detectCloudFlare()
+    public static function detectCloudflare()
     {
         if (!empty($_SERVER['HTTP_CF_IPCOUNTRY'])
             || !empty($_SERVER['HTTP_CF_CONNECTING_IP'])

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -39,7 +39,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        // Forse HTTPS if using CloudFlare "Flexible SSL"
+        // Force HTTPS if using Cloudflare "Flexible SSL"
         // https://support.cloudflare.com/hc/en-us/articles/200170416-What-do-the-SSL-options-mean-
         if (\Helper::isHttps()) {
             // $_SERVER['HTTPS'] = 'on';

--- a/config/app.php
+++ b/config/app.php
@@ -422,7 +422,7 @@ return [
     'curl_timeout'         => env('APP_CURL_TIMEOUT', 40),
     // Should be set for Guzzle. Curl has default CURLOPT_CONNECTTIMEOUT=30 sec.
     'curl_connect_timeout' => env('APP_CURL_CONNECTION_TIMEOUT', 30),
-    // CloudFlare may block requests without user agent.
+    // Cloudflare may block requests without user agent.
     // Need to be set for curl. Guzzle sends it's own user agent: GuzzleHttp/6.3.3 curl/7.58.0 PHP/8.2.5
     'curl_user_agent'      => env('APP_CURL_USER_AGENT', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 7_1_4) AppleWebKit/603.26 (KHTML, like Gecko) Chrome/55.0.3544.220 Safari/534'),
     // Should be set for curl and Guzzle.
@@ -498,7 +498,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Let the application know that CloudFlare is used (for proper client IP detection).
+    | Let the application know that Cloudflare is used (for proper client IP detection).
     |-------------------------------------------------------------------------
     */
     'cloudflare_is_used'    => env('APP_CLOUDFLARE_IS_USED', false),

--- a/overrides/symfony/http-foundation/Request.php
+++ b/overrides/symfony/http-foundation/Request.php
@@ -890,7 +890,7 @@ class Request
      */
     public function getClientIps()
     {
-        // Fix for CloudFlare.
+        // Fix for Cloudflare.
         if (isset($_SERVER["HTTP_CF_CONNECTING_IP"])
             && $_SERVER['REMOTE_ADDR'] != $_SERVER["HTTP_CF_CONNECTING_IP"]
             && config('app.cloudflare_is_used')

--- a/resources/views/system/status.blade.php
+++ b/resources/views/system/status.blade.php
@@ -54,7 +54,7 @@
                 <th>{{ __('Protocol') }}</th>
                 <td class="table-main-col" id="system-app-protocol"></td>
             </tr>
-            @if (\Helper::detectCloudFlare())
+            @if (\Helper::detectCloudflare())
                 @php
                     $cloudflare_is_used = config('app.cloudflare_is_used');
                 @endphp
@@ -62,7 +62,7 @@
                     <th>Proxy</th>
                     <td class="table-main-col">
                         <div @if (!$cloudflare_is_used) class="alert alert-warning alert-narrow margin-bottom-0" @endif>
-                            @if (!$cloudflare_is_used)<i class="glyphicon glyphicon-exclamation-sign"></i> @endif{{ 'CloudFlare' }} (<a href="{{ config('app.freescout_repo') }}/wiki/Installation-Guide#103-cloudflare" target="_blank">{{ __('read more') }}</a>)
+                            @if (!$cloudflare_is_used)<i class="glyphicon glyphicon-exclamation-sign"></i> @endif{{ 'Cloudflare' }} (<a href="{{ config('app.freescout_repo') }}/wiki/Installation-Guide#103-cloudflare" target="_blank">{{ __('read more') }}</a>)
                         </div>
                     </td>
                 </tr>


### PR DESCRIPTION
[Cloudflare dropped their capital "F"](https://blog.cloudflare.com/time-for-an-update/) so I thought I'd quickly update the FreeScout codebase to match. Thanks to the maintainers for your hard work!