### PR TITLE
Adds functionality to mark notifications as unread

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -506,6 +506,44 @@ class UsersController extends Controller
                 }
                 break;
 
+		        case 'mark_notifications_as_unread':
+				        if (!$auth_user) {
+						        $response['msg'] = __('You are not logged in');
+				        }
+				        if (!$response['msg']) {
+						        // Get the notification IDs to mark as unread
+						        $notification_ids = $request->notification_ids ?? [];
+
+						        if (empty($notification_ids)) {
+								        // Mark all read notifications as unread (within a reasonable timeframe, e.g., last month)
+								        $auth_user->notifications()
+								                  ->whereNotNull('read_at')
+								                  ->where('created_at', '>', now()->subDays(30))
+								                  ->update(['read_at' => null]);
+						        } else {
+								        // Mark only specific notifications as unread
+								        $auth_user->notifications()
+								                  ->whereIn('id', $notification_ids)
+								                  ->update(['read_at' => null]);
+						        }
+
+						        $auth_user->clearWebsiteNotificationsCache();
+
+						        $response['status'] = 'success';
+						        $response['unread_count'] = $auth_user->unreadNotifications()->count();
+				        }
+				        break;
+
+		        case 'get_unread_count':
+				        if (!$auth_user) {
+						        $response['msg'] = __('You are not logged in');
+				        }
+				        if (!$response['msg']) {
+						        $response['status'] = 'success';
+						        $response['count'] = $auth_user->unreadNotifications()->count();
+				        }
+				        break;
+
             default:
                 $response['msg'] = 'Unknown action';
                 break;

--- a/app/User.php
+++ b/app/User.php
@@ -846,6 +846,7 @@ class User extends Authenticatable
     public function clearWebsiteNotificationsCache()
     {
         \Cache::forget('user_web_notifications_'.$this->id);
+		    \Event::dispatch('user.notifications_cache_cleared', [$this->id]);
     }
 
     public function getPhotoUrl($default_if_empty = true)
@@ -860,6 +861,11 @@ class User extends Authenticatable
             return asset('/img/default-avatar.png');
         }
     }
+
+		public function getUnreadNotificationsCount()
+		{
+				return $this->unreadNotifications()->count();
+		}
 
     /**
      * Resize and save user photo.

--- a/resources/views/users/partials/web_notifications.blade.php
+++ b/resources/views/users/partials/web_notifications.blade.php
@@ -31,6 +31,13 @@
                 <div class="web-notification-msg-preview">
                     {{ App\Misc\Helper::textPreview($web_notification_data['last_thread_body']) }}
                 </div>
+                @if ($web_notification_data['notification']->read_at)
+                    <span class="web-notification-mark-unread"
+                       data-notification-id="{{ $web_notification_data['notification']->id }}"
+                       title="{{ __('Mark as unread') }}">
+                        Mark as unread
+                    </span>
+                @endif
             </div>
         </a>
     </li>


### PR DESCRIPTION
Allows users to mark notifications as unread.
Improves user experience by providing a way to revisit notifications.

Refreshes notification counter periodically without user interaction.