### PR TITLE
Update email.user_notification.subject Eventy filter

### DIFF
--- a/app/Mail/UserNotification.php
+++ b/app/Mail/UserNotification.php
@@ -91,7 +91,7 @@ class UserNotification extends Mailable
             });
         }
 
-        $subject = \Eventy::filter('email.user_notification.subject','[#'.(isset($this->conversation->number)?$this->conversation->number:'').'] '.$this->conversation->subject);
+        $subject = \Eventy::filter('email.user_notification.subject', '[#' . (isset($this->conversation->number) ? $this->conversation->number : '') . '] ' . $this->conversation->subject, $this->conversation);
 
         $customer = $this->conversation->customer;
 


### PR DESCRIPTION
Added `$this->conversation` parameter to allow the Ticket Module to override the email subject.

@freescout-help-desk  Can the Ticket Module hooks function be updated to include this event:

```
        \Eventy::addFilter('email.user_notification.subject', function($subject, $conversation) {
            $prefix = config('ticketnumber.prefix');
            $suffix = config('ticketnumber.suffix');
            return $prefix.$conversation->number.$suffix.$conversation->subject;
        }, 20, 2);
```