### PR TITLE
Add 'fetch_emails.preprocess_body' filter

### DIFF
--- a/app/Console/Commands/FetchEmails.php
+++ b/app/Console/Commands/FetchEmails.php
@@ -1357,6 +1357,9 @@ class FetchEmails extends Command
 
         $result = '';
 
+        // Can fix broken HTML, remove sensitive parts and etc.  Actual work is done by custom Module.
+        $body = \Eventy::filter('fetch_emails.preprocess_body', $body);
+
         if ($is_html) {
             // Extract body content from HTML
             


### PR DESCRIPTION
See https://github.com/freescout-help-desk/freescout/issues/4773

When fetching emails FetchEmails.php will trigger `fetch_emails.preprocess_body` even at start of `separateReply` method.

The idea is to use own Module with custom logic that'll survive updates of FreeScout version.
