### PR TITLE
Implement body parameter for new-ticket

### DIFF
--- a/app/Http/Controllers/ConversationsController.php
+++ b/app/Http/Controllers/ConversationsController.php
@@ -449,6 +449,10 @@ class ConversationsController extends Controller
                 }
             }
         }
+        if ($request->get('body')) {
+            $thread = new Thread();
+            $thread->body = $request->get('body');
+        }
 
         $conversation->subject = $subject;
 


### PR DESCRIPTION
Adds a body paramter to the new-ticket URL - so it is possible now to prefill subject, to address and the body.

Example Usage:

https://freescout.example.de/mailbox/1/new-ticket?to=to@jobraun.de&subject=testsubject&body=Test123%3Cbr%3E%0A%3Cp%3ETest1324%3C%2Fp%3E%0A%3Cbr%3E%0A%3Cbr%3E%0A%3Cp%3E%3Cb%3Ebold%3C%2Fb%3E%3C%2Fp%3E
