### PR TITLE
Fix PostgreSQL notification conversation binding

### DIFF
--- a/app/Notifications/BroadcastNotification.php
+++ b/app/Notifications/BroadcastNotification.php
@@ -106,7 +106,7 @@ class BroadcastNotification extends Notification implements ShouldQueue
 
             // Get last reply or note of the conversation to display it's text
             $last_thread_body = '';
-            $last_thread = Thread::where('conversation_id', $conversation)
+            $last_thread = Thread::where('conversation_id', $conversation->id)
                 // Select must contain all fields from orderBy() to avoid:
                 // General error: 3065 Expression #1 of ORDER BY clause is not in SELECT
                 ->select(['body', 'created_at'])


### PR DESCRIPTION
## What changed

- Bind the integer conversation ID when fetching the latest thread for email-backed web notifications.

## Why

`BroadcastNotification::fetchPayloadData()` passed an `App\Conversation` model directly to the `conversation_id` query predicate. PostgreSQL rejects the serialized model value as invalid input for the integer foreign-key column, causing `SQLSTATE[22P02]` when user email notifications are generated.

Using `$conversation->id` restores the intended scalar foreign-key binding and remains compatible with other supported databases.

Fixes #5553.