### PR TITLE
Apply module migrations when the Modules folder resolves outside the app folder

### DIFF
--- a/app/Console/Commands/ModuleMigrate.php
+++ b/app/Console/Commands/ModuleMigrate.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * php artisan module:migrate modulename.
+ *
+ * Replaces the command from nwidart/laravel-modules, which passes the module's
+ * migrations folder to the migrate command after removing base_path() from it.
+ * Module::getPath() is a realpath(), so on installations where the Modules
+ * folder is a symlink leading outside of the application folder (a common
+ * container layout: /var/www/html/Modules -> /data/Modules) base_path() does
+ * not occur in that path. The value stays absolute, migrate prefixes
+ * base_path() to it anyway (Illuminate\Database\Console\Migrations\
+ * BaseCommand::getMigrationPaths()), the resulting folder does not exist and
+ * the migration reports "Nothing to migrate" with a zero exit code.
+ *
+ * https://github.com/freescout-help-desk/freescout/issues/5569
+ */
+
+namespace App\Console\Commands;
+
+use Nwidart\Modules\Commands\MigrateCommand;
+use Nwidart\Modules\Migrations\Migrator;
+use Nwidart\Modules\Module;
+
+class ModuleMigrate extends MigrateCommand
+{
+    /**
+     * Run the migrations of the specified module.
+     *
+     * @param Module $module
+     */
+    protected function migrate(Module $module)
+    {
+        $path = $this->getMigrationPath($module);
+
+        if ($this->option('subpath')) {
+            $path = $path.'/'.$this->option('subpath');
+        }
+
+        $this->call('migrate', [
+            '--path'     => $path,
+            '--database' => $this->option('database'),
+            '--pretend'  => $this->option('pretend'),
+            '--force'    => $this->option('force'),
+        ]);
+
+        if ($this->option('seed')) {
+            $this->call('module:seed', ['module' => $module->getName()]);
+        }
+    }
+
+    /**
+     * Get the module's migrations folder relative to base_path(), as the
+     * migrate command prepends base_path() to whatever --path receives.
+     *
+     * @param Module $module
+     *
+     * @return string
+     */
+    protected function getMigrationPath(Module $module)
+    {
+        $absolute_path = (new Migrator($module))->getPath();
+
+        $path = str_replace(base_path(), '', $absolute_path);
+
+        if ($path != $absolute_path) {
+            // The module is located inside of the application folder.
+            return $path;
+        }
+
+        // The module path is a realpath() leading outside of the application
+        // folder. Rebuild the path from the folder the module has been scanned
+        // from, which still contains the symlink and is therefore located
+        // inside of the application folder.
+        $module_path = $module->getPath();
+
+        if (method_exists($module, 'getScannedPath')
+            && $module_path
+            && strpos($absolute_path, $module_path) === 0
+        ) {
+            $scanned_path = str_replace(base_path(), '', $module->getScannedPath());
+            $scanned_path .= substr($absolute_path, strlen($module_path));
+
+            if (is_dir(base_path().DIRECTORY_SEPARATOR.$scanned_path)) {
+                return $scanned_path;
+            }
+        }
+
+        // Neither path is located inside of the application folder, so the
+        // migrate command can not resolve it. Tell the user instead of
+        // reporting "Nothing to migrate".
+        $this->error('Module migrations folder is located outside of the application folder: '.$absolute_path);
+        $this->error('Run "php artisan migrate" to apply the module migrations.');
+
+        return $path;
+    }
+}

--- a/overrides/nwidart/laravel-modules/src/Module.php
+++ b/overrides/nwidart/laravel-modules/src/Module.php
@@ -33,6 +33,15 @@ abstract class Module extends ServiceProvider
     protected $path;
 
     /**
+     * The module path as it has been scanned, before realpath() resolved it.
+     * When the Modules folder is a symlink leading outside of the application
+     * folder, this is the only path which is still relative to base_path().
+     *
+     * @var string
+     */
+    protected $scanned_path;
+
+    /**
      * @var array of cached Json objects, keyed by filename
      */
     protected $moduleJson = [];
@@ -49,6 +58,7 @@ abstract class Module extends ServiceProvider
         parent::__construct($app);
         $this->name = $name;
         $this->path = realpath($path);
+        $this->scanned_path = $path;
     }
 
     /**
@@ -149,6 +159,16 @@ abstract class Module extends ServiceProvider
     public function getPath()
     {
         return $this->path;
+    }
+
+    /**
+     * Get the path the module has been scanned from, with symlinks not resolved.
+     *
+     * @return string
+     */
+    public function getScannedPath()
+    {
+        return $this->scanned_path ?: $this->path;
     }
 
     /**

--- a/overrides/nwidart/laravel-modules/src/Repository.php
+++ b/overrides/nwidart/laravel-modules/src/Repository.php
@@ -202,7 +202,11 @@ abstract class Repository implements RepositoryInterface, Countable
         $modules = [];
 
         foreach ($cached as $name => $module) {
-            $path = $module['path'];
+            // Prefer the path the module has been scanned from, with symlinks
+            // not resolved yet - the constructor resolves it again, so getPath()
+            // stays the same, but the module also knows its original location.
+            // Modules cached before this was stored only have 'path'.
+            $path = !empty($module['scanned_path']) ? $module['scanned_path'] : $module['path'];
 
             $modules[$name] = $this->createModule($this->app, $name, $path);
         }
@@ -223,12 +227,21 @@ abstract class Repository implements RepositoryInterface, Countable
 
         return $this->app['cache']->remember($this->config('cache.key'), $this->config('cache.lifetime'), function () {
 
+            $modules = $this->scan();
+
             // By some reason when Nwidart\Modules\Module is converted into array
-            $array = $this->toCollection()->toArray();
+            $array = (new Collection($modules))->toArray();
             // Set `active` flag from DB for each module
             foreach ($array as $key => $item) {
                 if (!empty($item['alias'])) {
                     $item['active'] = (int) \App\Module::isActive($item['alias']);
+                }
+
+                // Collection::toArray() only keeps the resolved path, but the
+                // path the module has been scanned from is needed to build
+                // migration paths relative to base_path().
+                if (isset($modules[$key]) && method_exists($modules[$key], 'getScannedPath')) {
+                    $array[$key]['scanned_path'] = $modules[$key]->getScannedPath();
                 }
             }
 


### PR DESCRIPTION
Fixes #5569.

## The problem an admin runs into

You press "Update" on a module in Manage → Modules. FreeScout downloads the new version and shows a green "module successfully updated!" banner. What it does not do is create the database tables and columns the new version needs. There is no error and nothing in `storage/logs`.

The module then runs with a schema that belongs to the previous version. Depending on the module, features quietly do nothing or requests fail with "Base table or view not found". Nothing retries the database update, so the install stays broken until somebody happens to find Manage → System → Tools → "Migrate DB" (or the red "Migrate DB" button on the Status page) and presses it. That single click applies everything, which makes the whole thing look random rather than reproducible.

Activating a module on the same install has the same result: the module ends up active with none of its tables created.

## Why it happens

FreeScout applies a module's migrations by handing the module's `Database/Migrations` folder to Laravel's `migrate` command. That folder has to be passed relative to the FreeScout folder, and the conversion assumes the module lives inside it.

On installs where `Modules` is a symlink to storage outside the FreeScout folder, that assumption breaks. `/var/www/html/Modules` pointing at `/data/Modules` on a volume is the standard way to keep modules across container restarts, so this affects a large share of Docker and PaaS installs. FreeScout ends up looking for the migration files in a folder that does not exist, `migrate` reports `Nothing to migrate.` and exits successfully, and the update continues and reports success.

Two things make this hard to spot:

- Installs where `Modules` is a real folder are unaffected, because the conversion works there. Development machines and bare-metal installs fall into that group, so this does not show up in testing.
- `php artisan migrate` *does* apply these migrations, and that is what the Migrate DB button uses. It works because module service providers register their own migration folders through `loadMigrationsFrom()`, and those absolute paths never go through the conversion. The broken path is the module-scoped one that activating and updating a module use.

The fallback `migrate --force` that `ModulesController` runs after activating a module does not save it either: in the request that activates the module, the module's service provider has not been registered, so that plain `migrate` has no module migration paths registered yet. The tables appear only once something runs `migrate` in a later process.

## The technical chain

1. `Repository::scan()` globs `base_path('Modules')/*/module.json`, so the module object is constructed with `/var/www/html/Modules/MyModule`, symlink intact.
2. `overrides/nwidart/laravel-modules/src/Module.php:51` stores `realpath($path)`, turning it into `/data/Modules/MyModule`, outside `base_path()`. This line comes from nwidart 2.7.0 itself, not from FreeScout.
3. `vendor/nwidart/laravel-modules/src/Commands/MigrateCommand.php:62` builds the `--path` option with `str_replace(base_path(), '', $migrationPath)`. `base_path()` does not occur in `/data/Modules/…`, so the value stays absolute and keeps pointing outside the app.
4. `Illuminate\Database\Console\Migrations\BaseCommand::getMigrationPaths()` returns `$this->laravel->basePath().'/'.$path` for any `--path`, with no check for an absolute value, so the migrator scans `/var/www/html//data/Modules/MyModule/Database/Migrations`, which does not exist.
5. `migrate` finds no files there, prints `Nothing to migrate.` and returns exit code 0. Nothing for `freescout:module-install` to detect.

Upstream nwidart fixed this class of bug by passing `--realpath => true` and dropping the `base_path()` replacement, but that option only exists in Laravel 5.6 and later.

## What the patch does

- `overrides/nwidart/laravel-modules/src/Module.php`: keeps `realpath()` for `getPath()` and stores the path the module was scanned from behind a new `getScannedPath()`. Nothing existing changes behaviour, so `getExtraPath()` and the module `Public` symlink target keep resolving as they do today.
- `overrides/nwidart/laravel-modules/src/Repository.php`: carries that path through the modules cache. `Collection::toArray()` keeps `getPath()` only, so a module hydrated from the cache would otherwise lose it, and the cache is enabled by default.
- `app/Console/Commands/ModuleMigrate.php`: replaces `module:migrate` and builds the `--path` from the scanned path when the resolved one falls outside the FreeScout folder. The result is checked with `is_dir()` first, and when neither path is inside the FreeScout folder the command reports that and points at `php artisan migrate`, instead of reporting success.

Fixing the path rather than adding another `migrate` call after an update also keeps `php artisan module:migrate <Module>` working for CLI and scripted installs.

## Verification

I built a throwaway container that mirrors the layout from the issue: FreeScout in `/var/www/html`, `Modules` a symlink to `/data/Modules` on a separate volume, MariaDB 11.4, PHP 8.2, FreeScout 1.8.231. The module is a real public one ([KapsoWhatsApp](https://github.com/automaze-me/freescout-kapsowhatsapp), MIT), installed at 0.2.6, whose 0.3.0 release adds two migrations. Both runs use the Modules page in the browser, not the console.

| Step on that install | Before the patch | After the patch |
|---|---|---|
| Activate the module | active, 0 tables, 0 migration rows | active, 3 tables, 10 migration rows |
| Update 0.2.6 → 0.3.0 | files updated to 0.3.0, schema untouched (8 rows), `kapso_whatsapp_contacts` and `contact_bsuid` missing | files updated to 0.3.0, 10 rows, table and column created |

The banner the admin sees before the patch, in full:

```
"WhatsApp (Kapso)" module successfully updated!
Cache cleared successfully. Nothing to migrate. Public symlink already exists ...
```

and after it:

```
"WhatsApp (Kapso)" module successfully updated!
Cache cleared successfully.
Migrating: 2026_08_05_000001_create_kapso_whatsapp_contacts_table
Migrated:  2026_08_05_000001_create_kapso_whatsapp_contacts_table
Migrating: 2026_08_05_000002_add_contact_bsuid_to_kapso_whatsapp_messages_table
Migrated:  2026_08_05_000002_add_contact_bsuid_to_kapso_whatsapp_messages_table
```

On top of that, on a normal (not symlinked) install:

- `php artisan module:migrate <Module> --force` and `php artisan freescout:module-install <alias>` both apply a pending module migration, where the unpatched code prints `Nothing to migrate.` for the symlinked case.
- The scanned path survives both routes into the repository, the fresh scan and the cached hydration, since only the cached one was broken.
- As a regression check I compared the computed `--path` against what nwidart computes today for all 13 modules installed on a normal layout: identical in every case, so nothing changes where the bug does not apply.
- `phpcs --standard=phpcs.xml app/Console/Commands/ModuleMigrate.php` passes. The `overrides` folder is excluded by `phpcs.xml`.

One thing I left out on purpose: the Modules page still reports a successful update if migrations fail to run for some other reason. `SystemController.php:218` already collects pending migrations for the Status page, so surfacing them in the update result would close that gap. Happy to add it here or in a separate PR, whichever you prefer.
