### PR TITLE
Add RepoCloud to one-click install options

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ There are no minimum system requirements (CPU / RAM) – FreeScout will run on a
 * [Softaculous](http://www.softaculous.com/apps/customersupport/FreeScout) — cPanel, Plesk, ISPmanager, H-Sphere, DirectAdmin, InterWorx
 * [Fantastico](http://ff3.netenberg.com/visitors/scripts/freescout/view) — cPanel, DirectAdmin, ISP Manager, ISP Config
 * [Cloudron](https://cloudron.io/store/net.freescout.cloudronapp.html)
+* [RepoCloud](https://repocloud.io/details/FreeScout/) — One-click cloud deployment
 * [Ubuntu](https://github.com/freescout-help-desk/freescout/wiki/Installation-Guide#interactive-installation-bash-script-ubuntu) — Bash script
 
  [More options…](https://freescout.net/cloud-hosted/)


### PR DESCRIPTION
This PR adds [RepoCloud](https://repocloud.io/details/FreeScout/) as a deployment option in the "Images & One-Click Installs" section of the README.

RepoCloud provides one-click cloud deployment for open-source applications, making it easy for users to self-host FreeScout without manual server setup.