### PR TITLE
Add an optional embedded player for audio attachments

### DIFF
--- a/app/Attachment.php
+++ b/app/Attachment.php
@@ -344,6 +344,23 @@ class Attachment extends Model
     }
 
     /**
+     * Check if the attachment is an audio file which the browser receives
+     * inline rather than as a download, and can therefore be played by an
+     * <audio> element. Mirrors the conditions in
+     * OpenController::downloadAttachment().
+     */
+    public function isPlayableAudio()
+    {
+        if (!preg_match('#^audio/.*$#', (string) $this->mime_type)) {
+            return false;
+        }
+
+        $extension = strtolower(pathinfo($this->file_name, PATHINFO_EXTENSION));
+
+        return in_array($extension, config('app.viewable_attachments'));
+    }
+
+    /**
      * Check if the attachment file actually exists on the disk.
      */
     public function fileExists()

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -203,6 +203,7 @@ class SettingsController extends Controller
                     'user_permissions'     => User::getGlobalUserPermissions(),
                     'email_branding'       => Option::get('email_branding'),
                     'open_tracking'        => Option::get('open_tracking'),
+                    'audio_player'         => Option::get('audio_player'),
                     'email_conv_history'   => config('app.email_conv_history'),
                     'max_message_size'     => config('app.max_message_size'),
                     'email_user_history'   => config('app.email_user_history'),

--- a/config/app.php
+++ b/config/app.php
@@ -247,6 +247,7 @@ return [
         'alert_fetch_period' => ['default' => 15], // min
         'email_branding'     => ['default' => true],
         'open_tracking'      => ['default' => true],
+        'audio_player'       => ['default' => true],
         'subscription_defaults' => ['default' => []],
     ],
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -2386,6 +2386,16 @@ button.conv-checkbox-clear {
     text-decoration: none;
     cursor: default;
 }
+.thread-attachments li.attachment-with-player {
+    display: block;
+    max-width: 420px;
+}
+.thread-attachments .attachment-player {
+    display: block;
+    width: 100%;
+    height: 32px;
+    margin-top: 6px;
+}
 .thread-editor-container {
     padding: 20px;
 }

--- a/resources/views/conversations/partials/thread_attachments.blade.php
+++ b/resources/views/conversations/partials/thread_attachments.blade.php
@@ -1,13 +1,23 @@
 @if ($thread->has_attachments)
+    @php
+        $audio_player_enabled = \Option::get('audio_player');
+    @endphp
     <div class="thread-attachments">
         <i class="glyphicon glyphicon-paperclip"></i>
         <ul>
             @foreach ($thread->attachments as $attachment)
-                <li data-attachment-id="{{ $attachment->id }}" data-mime="{{ $attachment->mime_type }}">
+                @php
+                    $show_audio_player = $audio_player_enabled && $attachment->isPlayableAudio();
+                @endphp
+                <li data-attachment-id="{{ $attachment->id }}" data-mime="{{ $attachment->mime_type }}" @if ($show_audio_player)class="attachment-with-player"@endif>
                     <a href="{{ $attachment->url() }}" class="attachment-link break-words" target="_blank">{{ $attachment->file_name }}</a>
                     <span class="text-help">({{ $attachment->getSizeName() }})</span>
                     <a href="{{ $attachment->url() }}" download><i class="glyphicon glyphicon-download-alt small"></i></a>
                     @action('thread.attachment_append', $attachment, $thread, $conversation, $mailbox)
+                    @if ($show_audio_player)
+                        {{-- preload="none" so opening a conversation does not fetch every audio file. --}}
+                        <audio class="attachment-player" controls preload="none" src="{{ $attachment->url() }}"></audio>
+                    @endif
                 </li>
             @endforeach
             @action('thread.attachments_list_append', $thread, $conversation, $mailbox)

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -131,6 +131,23 @@
         </div>
     </div>
 
+    <div class="form-group{{ $errors->has('settings[audio_player]') ? ' has-error' : '' }}">
+        <label for="audio_player" class="col-sm-2 control-label">{{ __('Audio Player') }}</label>
+
+        <div class="col-sm-6">
+            <div class="controls">
+                <div class="onoffswitch-wrap">
+                    <div class="onoffswitch">
+                        <input type="checkbox" name="settings[audio_player]" value="1" id="audio_player" class="onoffswitch-checkbox" @if (old('settings[audio_player]', $settings['audio_player']))checked="checked"@endif >
+                        <label class="onoffswitch-label" for="audio_player"></label>
+                    </div>
+                </div>
+                <p class="form-help">{{ __('Play audio attachments in the conversation instead of opening them in a new browser tab.') }}</p>
+            </div>
+            @include('partials/field_error', ['field'=>'settings.audio_player'])
+        </div>
+    </div>
+
     <div class="form-group{{ $errors->has('settings[email_branding]') ? ' has-error' : '' }}">
         <label for="email_branding" class="col-sm-2 control-label">{{ __('Spread the Word', ['app_name' => \Config::get('app.name')]) }}</label>
 


### PR DESCRIPTION
Audio attachments could only be listened to by opening them in a new browser tab. For mailboxes handling voicemail that means a tab per message, so render an <audio> player inline in the conversation instead.

The player is controlled by an Audio Player toggle in Settings -> General, defaulting to on, so installations that prefer the plain attachment list can turn it off.

Only attachments that the browser actually receives inline get a player: Attachment::isPlayableAudio() mirrors the audio mime type and viewable_attachments extension checks in
OpenController::downloadAttachment(), so a file that would be forced to download does not get a player that can never load. Players use preload="none" so opening a conversation does not fetch every audio file on it.

Keep in mind that pull requests should be sent to the `master` branch! See https://github.com/freescout-helpdesk/freescout/wiki/Development-Guide#github-workflow

Now you can delete this text and type the description of your pull request...