### PR TITLE
Always show "From:" when a thread's actual customer differs from the conversation's current owner

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -2210,6 +2210,9 @@ button.conv-checkbox-clear {
 .thread-recipients strong {
     color: #72808e;
 }
+.thread-recipients .text-warning strong {
+    color: inherit;
+}
 .thread-recipients div {
     margin-top: 2px;
 }

--- a/resources/views/conversations/partials/thread.blade.php
+++ b/resources/views/conversations/partials/thread.blade.php
@@ -104,11 +104,22 @@
                     @if ($thread->type != App\Thread::TYPE_NOTE || $thread->isForward())
                         <div class="thread-recipients">
                             @action('thread.before_recipients', $thread, $loop, $threads, $conversation, $mailbox)
+                            @php
+                                // The thread's actual author may differ from who the conversation
+                                // is currently attributed to (e.g. two customer records with the
+                                // same display name but different emails, or a conversation
+                                // reassigned after the fact) - worth calling out even if nothing
+                                // else about this message looks unusual. Computed up front, not as
+                                // part of the ||-chain below, so it stays reliable regardless of
+                                // which of the other conditions short-circuits the evaluation.
+                                $owner_mismatch = $thread->isCustomerMessage() && isset($conversation) && $thread->customer_id != $conversation->customer_id;
+                            @endphp
                             @if (($thread->isUserMessage() && $thread->from && array_key_exists($thread->from, $mailbox->getAliases()))
                                 || ($thread->isCustomerMessage() && isset($customer) && count($customer->emails) > 1)
                                 || ($thread->isCustomerMessage() && ($from_header = $thread->getFromIfDifferentFromReplyTo($customer ?? null)))
+                                || $owner_mismatch
                             )
-                                <div @if (!empty($from_header)) class="text-warning" @endif>
+                                <div @if (!empty($from_header) || $owner_mismatch) class="text-warning" @endif>
                                     <strong>
                                         {{ __("From") }}:
                                     </strong>

--- a/resources/views/conversations/partials/thread.blade.php
+++ b/resources/views/conversations/partials/thread.blade.php
@@ -105,25 +105,28 @@
                         <div class="thread-recipients">
                             @action('thread.before_recipients', $thread, $loop, $threads, $conversation, $mailbox)
                             @php
+                                // Computed unconditionally and fresh for every thread (not as a
+                                // side effect inside the ||-chain below, which only runs this on
+                                // some iterations and would otherwise leave a stale value from a
+                                // previous thread in place).
+                                $from_header = $thread->isCustomerMessage() ? $thread->getFromIfDifferentFromReplyTo($customer ?? null) : '';
                                 // The thread's actual author may differ from who the conversation
                                 // is currently attributed to (e.g. two customer records with the
                                 // same display name but different emails, or a conversation
                                 // reassigned after the fact) - worth calling out even if nothing
-                                // else about this message looks unusual. Computed up front, not as
-                                // part of the ||-chain below, so it stays reliable regardless of
-                                // which of the other conditions short-circuits the evaluation.
+                                // else about this message looks unusual.
                                 $owner_mismatch = $thread->isCustomerMessage() && isset($conversation) && $thread->customer_id != $conversation->customer_id;
                             @endphp
                             @if (($thread->isUserMessage() && $thread->from && array_key_exists($thread->from, $mailbox->getAliases()))
                                 || ($thread->isCustomerMessage() && isset($customer) && count($customer->emails) > 1)
-                                || ($thread->isCustomerMessage() && ($from_header = $thread->getFromIfDifferentFromReplyTo($customer ?? null)))
+                                || !empty($from_header)
                                 || $owner_mismatch
                             )
                                 <div @if (!empty($from_header) || $owner_mismatch) class="text-warning" @endif>
                                     <strong>
                                         {{ __("From") }}:
                                     </strong>
-                                    {{ $from_header ?? $thread->from }}
+                                    {{ !empty($from_header) ? $from_header : $thread->from }}
                                 </div>
                             @endif
                             @if (($thread->isForward()


### PR DESCRIPTION
The existing visibility condition for the `From:` line only fires when the customer has multiple saved email addresses or when the raw `From` header differs from `Reply-To` for an address the author doesn't have on file. 

Neither covers the case where two separate customer records (each with one email) share the same display name. This may happen when e. g. working with emails from other ticket/support systems that use a generic `From` name (like, a company name) but use varying email addresses for different support topics.

A reply from the "other" customer renders with an identical-looking name and no indication that it's a different person/address, since the `customer_cached` name is the same string either way.

So, add `customer_id != conversation.customer_id` as an independent condition. Reuses the existing text-warning treatment rather than introducing a new visual language.

#### Background: when does this actually diverge?

Here are some more ways how a thread's `customer_id` and its conversation's `customer_id` may end up
different:

- **Merging conversations** moves every thread of the merged-in conversation over via `$thread->conversation_id = $this->id`, without touching the target conversation's `customer_id` at all. So, merging two tickets from two different customers with the same display name may lead to this situation.
- **Manually changing the customer** on a conversation updates only the conversation's `customer_id`/`customer_email`. Every thread written before that point keeps referencing the original customer.
- **Automatic reassignment on a sender mismatch** during mail fetching updates the conversation's customer to whoever most recently sent a matching reply (see GHSA-j49f-9g94-3wh4). Every earlier thread from the original customer now differs from the conversation's current owner.

In all three cases, today's UI gives no visual indication that a given message's actual author differs from whom the conversation is currently attributed to. Two customer records that happen to share a display name are indistinguishable at a glance.

