### PR TITLE
Configurable persistent storage disk (S3 support) for attachments and avatars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,3 +51,21 @@ APP_KEY=
 
 # Uncomment to see errors in your browser, don't forget to comment it back when debugging finished
 #APP_DEBUG=true
+
+# Disk used to store conversation attachments and user/customer avatars. Defaults to
+# "private" (local disk, storage/app). Set to "s3" to store this data on S3 (or any
+# S3-compatible provider) instead, e.g. for horizontally-scaled deployments.
+#PERSISTENT_DISK=s3
+
+# S3 credentials, only needed when PERSISTENT_DISK=s3.
+#AWS_ACCESS_KEY_ID=
+#AWS_SECRET_ACCESS_KEY=
+#AWS_DEFAULT_REGION=
+#AWS_BUCKET=
+
+# Only needed for S3-compatible providers other than AWS itself (e.g. MinIO, Hetzner
+# Object Storage, Wasabi, DigitalOcean Spaces).
+#AWS_ENDPOINT=
+#AWS_USE_PATH_STYLE_ENDPOINT=true
+# Optional public base URL override, e.g. a CDN in front of the bucket.
+#AWS_URL=

--- a/app/Attachment.php
+++ b/app/Attachment.php
@@ -311,15 +311,9 @@ class Attachment extends Model
         return $this->getDisk()->download($this->getStorageFilePath(), $file_name, $headers);
     }
 
-    /**
-     * Disk used to store attachment files. Configurable via the
-     * "filesystems.persistent_disk" config value (PERSISTENT_DISK env var),
-     * so attachments can be moved off local disk (e.g. to S3) without
-     * touching application code.
-     */
     public static function disk()
     {
-        return config('filesystems.persistent_disk', 'private');
+        return \App\Misc\Helper::persistentDisk();
     }
 
     private function getDisk()

--- a/app/Attachment.php
+++ b/app/Attachment.php
@@ -19,8 +19,6 @@ class Attachment extends Model
 
     const DIRECTORY = 'attachment';
 
-    const DISK = 'private';
-
     const MIME_TYPE_MAX_LENGTH = 127;
 
     // This token type was used for backward compatibility for some time
@@ -135,7 +133,7 @@ class Attachment extends Model
         $file_info = self::saveFileToDisk($attachment, $file_name, $content, $uploaded_file);
 
         $attachment->file_dir = $file_info['file_dir'];
-        $attachment->size = Storage::disk(self::DISK)->size($file_info['file_path']);
+        $attachment->size = Storage::disk(self::disk())->size($file_info['file_path']);
         $attachment->save();
 
         return $attachment;
@@ -155,21 +153,26 @@ class Attachment extends Model
         do {
             $i++;
             $file_path = self::DIRECTORY.DIRECTORY_SEPARATOR.$file_dir.$i.DIRECTORY_SEPARATOR.$file_name;
-        } while (Storage::disk(self::DISK)->exists($file_path));
+        } while (Storage::disk(self::disk())->exists($file_path));
 
         $file_dir .= $i.DIRECTORY_SEPARATOR;
 
         try {
             if ($uploaded_file) {
-                $uploaded_file->storeAs(self::DIRECTORY.DIRECTORY_SEPARATOR.$file_dir, $file_name, ['disk' => self::DISK]);
+                $uploaded_file->storeAs(self::DIRECTORY.DIRECTORY_SEPARATOR.$file_dir, $file_name, ['disk' => self::disk()]);
             } else {
-                Storage::disk(self::DISK)->put($file_path, $content);
+                // Storage::put() detects a stream resource and writes it via writeStream(),
+                // so callers can pass either a string or a stream without extra handling here.
+                Storage::disk(self::disk())->put($file_path, $content);
             }
         } catch (\Exception $e) {
             \Helper::logException($e, '[Attachment::saveFileToDisk()]');
         }
 
-        \Helper::sanitizeUploadedFileData($file_path, \Helper::getPrivateStorage(), $content);
+        // $content may be a stream resource rather than a string; the SVG sanitizer needs
+        // actual string content, so let it re-read the just-written file in that case instead
+        // of treating the resource as file content.
+        \Helper::sanitizeUploadedFileData($file_path, \Helper::getPrivateStorage(), is_resource($content) ? null : $content);
 
         return [
             'file_dir'  => $file_dir,
@@ -308,9 +311,20 @@ class Attachment extends Model
         return $this->getDisk()->download($this->getStorageFilePath(), $file_name, $headers);
     }
 
+    /**
+     * Disk used to store attachment files. Configurable via the
+     * "filesystems.persistent_disk" config value (PERSISTENT_DISK env var),
+     * so attachments can be moved off local disk (e.g. to S3) without
+     * touching application code.
+     */
+    public static function disk()
+    {
+        return config('filesystems.persistent_disk', 'private');
+    }
+
     private function getDisk()
     {
-        return Storage::disk(self::DISK);
+        return Storage::disk(self::disk());
     }
 
     /**
@@ -446,13 +460,14 @@ class Attachment extends Model
 
         $new_attachment->save();
 
-        try {
-            $attachment_file = new \Illuminate\Http\UploadedFile(
-                $this->getLocalFilePath(), $this->file_name,
-                null, null, true
-            );
+        $stream = null;
 
-            $file_info = Attachment::saveFileToDisk($new_attachment, $new_attachment->file_name, '', $attachment_file);
+        try {
+            // Read via the Storage disk abstraction as a stream (not getLocalFilePath()) so
+            // this also works when attachments are stored on a non-local disk (e.g. S3),
+            // without loading the whole file into memory.
+            $stream = $this->getFileStream();
+            $file_info = Attachment::saveFileToDisk($new_attachment, $new_attachment->file_name, $stream, null);
 
             if (!empty($file_info['file_dir'])) {
                 $new_attachment->file_dir = $file_info['file_dir'];
@@ -460,6 +475,10 @@ class Attachment extends Model
             }
         } catch (\Exception $e) {
             \Helper::logException($e);
+        } finally {
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
         }
 
         return $new_attachment;
@@ -468,5 +487,15 @@ class Attachment extends Model
     public function getFileContents()
     {
         return $this->getDisk()->get($this->getStorageFilePath());
+    }
+
+    /**
+     * Same as getFileContents(), but as a stream instead of loading the whole
+     * file into memory -- use this when the bytes are only being copied
+     * elsewhere (e.g. duplicating/forwarding an attachment).
+     */
+    public function getFileStream()
+    {
+        return $this->getDisk()->readStream($this->getStorageFilePath());
     }
 }

--- a/app/Conversation.php
+++ b/app/Conversation.php
@@ -2300,13 +2300,15 @@ class Conversation extends Model
                     // can be deleted along with attachments.
                     $new_attachment->save();
 
-                    try {
-                        $attachment_file = new \Illuminate\Http\UploadedFile(
-                            $attachment->getLocalFilePath(), $attachment->file_name,
-                            null, null, true
-                        );
+                    $stream = null;
 
-                        $file_info = Attachment::saveFileToDisk($new_attachment, $new_attachment->file_name, '', $attachment_file);
+                    try {
+                        // Read via the Storage disk abstraction as a stream (not
+                        // getLocalFilePath()) so this also works when attachments are stored
+                        // on a non-local disk (e.g. S3), without loading the whole file into
+                        // memory.
+                        $stream = $attachment->getFileStream();
+                        $file_info = Attachment::saveFileToDisk($new_attachment, $new_attachment->file_name, $stream, null);
 
                         if (!empty($file_info['file_dir'])) {
                             $new_attachment->file_dir = $file_info['file_dir'];
@@ -2317,6 +2319,10 @@ class Conversation extends Model
                         }
                     } catch (\Exception $e) {
                         \Helper::logException($e);
+                    } finally {
+                        if (is_resource($stream)) {
+                            fclose($stream);
+                        }
                     }
                 }
                 if ($thread_has_attachments) {

--- a/app/Customer.php
+++ b/app/Customer.php
@@ -1299,7 +1299,8 @@ class Customer extends Model
 
     public static function getPhotoUrlByFileName($file_name)
     {
-        return Storage::disk(self::photoDisk())->url(self::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$file_name);
+        // Streamed through the app so this works on S3 with private visibility too.
+        return route('photo.download', ['type' => 'customers', 'file_name' => $file_name]);
     }
 
     /**

--- a/app/Customer.php
+++ b/app/Customer.php
@@ -1299,18 +1299,12 @@ class Customer extends Model
 
     public static function getPhotoUrlByFileName($file_name)
     {
-        // Streamed through the app so this works on S3 with private visibility too.
-        return route('photo.download', ['type' => 'customers', 'file_name' => $file_name]);
+        return \App\Misc\Helper::urlForDiskPath(self::photoDisk(), self::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$file_name);
     }
 
-    /**
-     * Disk used to store the customer's photo. Same disk as Attachment::disk() and
-     * User::photoDisk() (config('filesystems.persistent_disk'), PERSISTENT_DISK env
-     * var) so all durable, user-generated files live in one place.
-     */
     public static function photoDisk()
     {
-        return config('filesystems.persistent_disk', 'private');
+        return \App\Misc\Helper::persistentDisk();
     }
 
     /**
@@ -1421,10 +1415,7 @@ class Customer extends Model
             Storage::disk(self::photoDisk())->delete(self::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$this->photo_url);
         }
 
-        // Encode into a stream instead of writing directly to a local path (imagejpeg($img,
-        // $path, ...)), so this also works when the photo disk is non-local (e.g. S3). Spills
-        // to a real temp file past 2 MB instead of holding the whole image in memory.
-        $stream = fopen('php://temp', 'r+');
+        $stream = \App\Misc\Helper::tempStream();
         imagejpeg($resized_image, $stream, self::PHOTO_QUALITY);
         rewind($stream);
 

--- a/app/Customer.php
+++ b/app/Customer.php
@@ -1299,7 +1299,17 @@ class Customer extends Model
 
     public static function getPhotoUrlByFileName($file_name)
     {
-        return Storage::url(self::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$file_name);
+        return Storage::disk(self::photoDisk())->url(self::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$file_name);
+    }
+
+    /**
+     * Disk used to store the customer's photo. Same disk as Attachment::disk() and
+     * User::photoDisk() (config('filesystems.persistent_disk'), PERSISTENT_DISK env
+     * var) so all durable, user-generated files live in one place.
+     */
+    public static function photoDisk()
+    {
+        return config('filesystems.persistent_disk', 'private');
     }
 
     /**
@@ -1404,19 +1414,22 @@ class Customer extends Model
         }
 
         $file_name = md5(Hash::make($this->id)).'.jpg';
-        $dest_path = Storage::path(self::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$file_name);
-
-        $dest_dir = pathinfo($dest_path, PATHINFO_DIRNAME);
-        if (!file_exists($dest_dir)) {
-            \File::makeDirectory($dest_dir, \Helper::DIR_PERMISSIONS);
-        }
 
         // Remove current photo
         if ($this->photo_url) {
-            Storage::delete(self::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$this->photo_url);
+            Storage::disk(self::photoDisk())->delete(self::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$this->photo_url);
         }
 
-        imagejpeg($resized_image, $dest_path, self::PHOTO_QUALITY);
+        // Encode into a stream instead of writing directly to a local path (imagejpeg($img,
+        // $path, ...)), so this also works when the photo disk is non-local (e.g. S3). Spills
+        // to a real temp file past 2 MB instead of holding the whole image in memory.
+        $stream = fopen('php://temp', 'r+');
+        imagejpeg($resized_image, $stream, self::PHOTO_QUALITY);
+        rewind($stream);
+
+        Storage::disk(self::photoDisk())->put(self::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$file_name, $stream);
+
+        fclose($stream);
 
         return $file_name;
     }
@@ -1427,7 +1440,7 @@ class Customer extends Model
     public function removePhoto()
     {
         if ($this->photo_url) {
-            Storage::delete(self::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$this->photo_url);
+            Storage::disk(self::photoDisk())->delete(self::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$this->photo_url);
         }
         $this->photo_url = '';
     }

--- a/app/Http/Controllers/OpenController.php
+++ b/app/Http/Controllers/OpenController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Attachment;
 use App\Conversation;
+use App\Customer;
 use App\Option;
 use App\Thread;
 use App\User;
@@ -329,6 +330,32 @@ class OpenController extends Controller
         }
 
         return $response;
+    }
+
+    /**
+     * Stream a user's or customer's avatar photo, so this works regardless of
+     * which disk (local or S3) is configured.
+     */
+    public function photo($type, $file_name)
+    {
+        $file_name = basename($file_name);
+
+        if ($type == 'users') {
+            $disk = User::photoDisk();
+            $path = User::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$file_name;
+        } elseif ($type == 'customers') {
+            $disk = Customer::photoDisk();
+            $path = Customer::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$file_name;
+        } else {
+            abort(404);
+        }
+
+        if (!\Storage::disk($disk)->exists($path)) {
+            abort(404);
+        }
+
+        return response(\Storage::disk($disk)->get($path))
+            ->header('Content-Type', \Storage::disk($disk)->mimeType($path));
     }
 
     /**

--- a/app/Http/Controllers/OpenController.php
+++ b/app/Http/Controllers/OpenController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Attachment;
 use App\Conversation;
-use App\Customer;
 use App\Option;
 use App\Thread;
 use App\User;
@@ -330,32 +329,6 @@ class OpenController extends Controller
         }
 
         return $response;
-    }
-
-    /**
-     * Stream a user's or customer's avatar photo, so this works regardless of
-     * which disk (local or S3) is configured.
-     */
-    public function photo($type, $file_name)
-    {
-        $file_name = basename($file_name);
-
-        if ($type == 'users') {
-            $disk = User::photoDisk();
-            $path = User::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$file_name;
-        } elseif ($type == 'customers') {
-            $disk = Customer::photoDisk();
-            $path = Customer::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$file_name;
-        } else {
-            abort(404);
-        }
-
-        if (!\Storage::disk($disk)->exists($path)) {
-            abort(404);
-        }
-
-        return response(\Storage::disk($disk)->get($path))
-            ->header('Content-Type', \Storage::disk($disk)->mimeType($path));
     }
 
     /**

--- a/app/Http/Controllers/OpenController.php
+++ b/app/Http/Controllers/OpenController.php
@@ -275,7 +275,12 @@ class OpenController extends Controller
             $csp_header_value .= ' allow-same-origin';
         }
 
-        if (config('app.download_attachments_via') == 'apache') {
+        // X-Sendfile, X-Accel-Redirect and the BinaryFileResponse fallback below all need
+        // a real local path, which Attachment::getLocalFilePath() can't give them for a
+        // non-local disk (e.g. S3) - fall through to streaming via Flysystem instead.
+        $is_local_disk = \App\Misc\Helper::isLocalDisk(Attachment::disk());
+
+        if ($is_local_disk && config('app.download_attachments_via') == 'apache') {
             // Send using Apache mod_xsendfile.
             $response = response(null)
                ->header('Content-Type', $attachment->mime_type)
@@ -288,14 +293,14 @@ class OpenController extends Controller
             } else {
                 $response->header('Content-Security-Policy', $csp_header_value);
             }
-        } elseif (config('app.download_attachments_via') == 'nginx') {
+        } elseif ($is_local_disk && config('app.download_attachments_via') == 'nginx') {
             // Send using Nginx.
             $response = response(null)
                ->header('Content-Type', $attachment->mime_type)
                // Laravel adds 'nosniff' by itself.
                //->header('X-Content-Type-Options', 'nosniff')
                ->header('X-Accel-Redirect', $attachment->getLocalFilePath(false));
-               
+
             if (!$view_attachment) {
                 $response->header('Content-Disposition', 'attachment; filename="'.$attachment->file_name.'"');
             } else {
@@ -318,7 +323,8 @@ class OpenController extends Controller
             // Browsers disable seeking without it, so audio and video attachments
             // can not be rewound or fast forwarded. BinaryFileResponse handles
             // Range requests, so use it whenever the file is shown in the browser.
-            if ($view_attachment && $attachment->fileExists()) {
+            // Only possible on a local disk, for the same reason as above.
+            if ($is_local_disk && $view_attachment && $attachment->fileExists()) {
                 $response = response()->file(
                     $attachment->getLocalFilePath(),
                     $headers

--- a/app/Mail/ReplyToCustomer.php
+++ b/app/Mail/ReplyToCustomer.php
@@ -160,15 +160,51 @@ class ReplyToCustomer extends Mailable
 
         if ($thread->has_attachments) {
             foreach ($thread->attachments as $attachment) {
-                if ($attachment->fileExists()) {
-                    $message->attach($attachment->getLocalFilePath());
-                } else {
-                    \Log::error('[ReplyToCustomer] Thread: '.$thread->id.'. Attachment file not find on disk: '.$attachment->getLocalFilePath());
-                }
+                $this->attachToMessage($message, $attachment, $thread->id);
             }
         }
 
         return $message;
+    }
+
+    /**
+     * Mailable::attachData() needs the whole attachment as an in-memory string;
+     * Mailable::attach() avoids that by reading a local path in chunks, but only
+     * accepts a real path. Swift_ByteStream_TemporaryFileByteStream gives us both:
+     * a real (temporary) local path SwiftMailer can stream from, and automatic
+     * cleanup via its own __destruct() once the message (and this attachment) is
+     * no longer referenced - no coordination with the caller/job needed.
+     */
+    private function attachToMessage($message, $attachment, $thread_id)
+    {
+        if (!$attachment->fileExists()) {
+            \Log::error('[ReplyToCustomer] Thread: '.$thread_id.'. Attachment file not find on disk: '.$attachment->getStorageFilePath());
+
+            return;
+        }
+
+        $stream = $attachment->getFileStream();
+        if (!is_resource($stream)) {
+            \Log::error('[ReplyToCustomer] Thread: '.$thread_id.'. Could not open attachment stream: '.$attachment->getStorageFilePath());
+
+            return;
+        }
+
+        $temp_file = new \Swift_ByteStream_TemporaryFileByteStream();
+        while (!feof($stream)) {
+            $temp_file->write(fread($stream, 8192));
+        }
+        $temp_file->commit();
+        fclose($stream);
+
+        $swift_attachment = (new \Swift_Attachment())->setFile($temp_file, $attachment->mime_type);
+        $swift_attachment->setFilename($attachment->file_name);
+
+        $message->withSwiftMessage(function ($swiftmessage) use ($swift_attachment) {
+            $swiftmessage->attach($swift_attachment);
+
+            return $swiftmessage;
+        });
     }
 
     /*

--- a/app/Misc/Helper.php
+++ b/app/Misc/Helper.php
@@ -948,6 +948,11 @@ class Helper
         return config('filesystems.persistent_disk', 'private');
     }
 
+    public static function isLocalDisk($disk)
+    {
+        return \Storage::disk($disk)->getDriver()->getAdapter() instanceof \League\Flysystem\Adapter\Local;
+    }
+
     /**
      * URL to deliver a file directly to the browser, without routing it through
      * the app: a plain URL for local disks, a temporary signed URL for disks
@@ -957,7 +962,7 @@ class Helper
     {
         $storage = \Storage::disk($disk);
 
-        if ($storage->getDriver()->getAdapter() instanceof \League\Flysystem\Adapter\Local) {
+        if (self::isLocalDisk($disk)) {
             return $storage->url($path);
         }
 

--- a/app/Misc/Helper.php
+++ b/app/Misc/Helper.php
@@ -940,6 +940,35 @@ class Helper
         return \Storage::disk('public');
     }
 
+    /**
+     * Disk configured for attachments and avatar photos (PERSISTENT_DISK env var).
+     */
+    public static function persistentDisk()
+    {
+        return config('filesystems.persistent_disk', 'private');
+    }
+
+    /**
+     * URL to deliver a file directly to the browser, without routing it through
+     * the app: a plain URL for local disks, a temporary signed URL for disks
+     * (e.g. S3) that require one because they aren't publicly readable.
+     */
+    public static function urlForDiskPath($disk, $path)
+    {
+        $storage = \Storage::disk($disk);
+
+        if ($storage->getDriver()->getAdapter() instanceof \League\Flysystem\Adapter\Local) {
+            return $storage->url($path);
+        }
+
+        return $storage->temporaryUrl($path, now()->addHour());
+    }
+
+    public static function tempStream()
+    {
+        return fopen('php://temp', 'r+');
+    }
+
     public static function formatException($e)
     {
         return 'Error: '.$e->getMessage().'; File: '.$e->getFile().' ('.$e->getLine().')';

--- a/app/User.php
+++ b/app/User.php
@@ -877,22 +877,16 @@ class User extends Authenticatable
         \Cache::forget('user_web_notifications_'.$this->id);
     }
 
-    /**
-     * Disk used to store the user's photo. Same disk as Attachment::disk() and
-     * Customer::photoDisk() (config('filesystems.persistent_disk'), PERSISTENT_DISK
-     * env var) so all durable, user-generated files live in one place.
-     */
     public static function photoDisk()
     {
-        return config('filesystems.persistent_disk', 'private');
+        return \App\Misc\Helper::persistentDisk();
     }
 
     public function getPhotoUrl($default_if_empty = true)
     {
         if (!empty($this->photo_url) || !$default_if_empty) {
             if (!empty($this->photo_url)) {
-                // Streamed through the app so this works on S3 with private visibility too.
-                return route('photo.download', ['type' => 'users', 'file_name' => $this->photo_url]);
+                return \App\Misc\Helper::urlForDiskPath(self::photoDisk(), self::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$this->photo_url);
             } else {
                 return '';
             }
@@ -930,10 +924,7 @@ class User extends Authenticatable
             Storage::disk(self::photoDisk())->delete(self::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$this->photo_url);
         }
 
-        // Encode into a stream instead of writing directly to a local path (imagejpeg($img,
-        // $path, ...)), so this also works when the photo disk is non-local (e.g. S3). Spills
-        // to a real temp file past 2 MB instead of holding the whole image in memory.
-        $stream = fopen('php://temp', 'r+');
+        $stream = \App\Misc\Helper::tempStream();
         imagejpeg($resized_image, $stream, self::PHOTO_QUALITY);
         rewind($stream);
 

--- a/app/User.php
+++ b/app/User.php
@@ -891,7 +891,8 @@ class User extends Authenticatable
     {
         if (!empty($this->photo_url) || !$default_if_empty) {
             if (!empty($this->photo_url)) {
-                return Storage::disk(self::photoDisk())->url(self::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$this->photo_url);
+                // Streamed through the app so this works on S3 with private visibility too.
+                return route('photo.download', ['type' => 'users', 'file_name' => $this->photo_url]);
             } else {
                 return '';
             }

--- a/app/User.php
+++ b/app/User.php
@@ -877,11 +877,21 @@ class User extends Authenticatable
         \Cache::forget('user_web_notifications_'.$this->id);
     }
 
+    /**
+     * Disk used to store the user's photo. Same disk as Attachment::disk() and
+     * Customer::photoDisk() (config('filesystems.persistent_disk'), PERSISTENT_DISK
+     * env var) so all durable, user-generated files live in one place.
+     */
+    public static function photoDisk()
+    {
+        return config('filesystems.persistent_disk', 'private');
+    }
+
     public function getPhotoUrl($default_if_empty = true)
     {
         if (!empty($this->photo_url) || !$default_if_empty) {
             if (!empty($this->photo_url)) {
-                return Storage::url(self::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$this->photo_url);
+                return Storage::disk(self::photoDisk())->url(self::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$this->photo_url);
             } else {
                 return '';
             }
@@ -913,22 +923,22 @@ class User extends Authenticatable
         }
 
         $file_name = md5(Hash::make($this->id)).'.jpg';
-        $dest_path = Storage::path(self::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$file_name);
-
-        $dest_dir = pathinfo($dest_path, PATHINFO_DIRNAME);
-        if (!file_exists($dest_dir)) {
-            \File::makeDirectory($dest_dir, 0755);
-        }
 
         // Remove current photo
         if ($this->photo_url) {
-            Storage::delete(self::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$this->photo_url);
+            Storage::disk(self::photoDisk())->delete(self::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$this->photo_url);
         }
 
-        imagejpeg($resized_image, $dest_path, self::PHOTO_QUALITY);
-        // $photo_url = $request->file('photo_url')->storeAs(
-        //     User::PHOTO_DIRECTORY, !Hash::make($user->id).'.jpg'
-        // );
+        // Encode into a stream instead of writing directly to a local path (imagejpeg($img,
+        // $path, ...)), so this also works when the photo disk is non-local (e.g. S3). Spills
+        // to a real temp file past 2 MB instead of holding the whole image in memory.
+        $stream = fopen('php://temp', 'r+');
+        imagejpeg($resized_image, $stream, self::PHOTO_QUALITY);
+        rewind($stream);
+
+        Storage::disk(self::photoDisk())->put(self::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$file_name, $stream);
+
+        fclose($stream);
 
         return $file_name;
     }
@@ -939,7 +949,7 @@ class User extends Authenticatable
     public function removePhoto()
     {
         if ($this->photo_url) {
-            Storage::delete(self::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$this->photo_url);
+            Storage::disk(self::photoDisk())->delete(self::PHOTO_DIRECTORY.DIRECTORY_SEPARATOR.$this->photo_url);
         }
         $this->photo_url = '';
     }

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         "ramsey/uuid": "3.9.6",
         "symfony/polyfill-mbstring": "v1.24.0",
         "webklex/php-imap": "4.1.1",
-        "enshrined/svg-sanitize": "0.22.0"
+        "enshrined/svg-sanitize": "0.22.0",
+        "league/flysystem-aws-s3-v3": "^1.0"
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "v3.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e597d601a6307036f019cd690319c679",
+    "content-hash": "a068505b66b85ec17f6ac259f0eaf405",
     "packages": [
         {
             "name": "anahkiasen/underscore-php",
@@ -60,6 +60,157 @@
             },
             "abandoned": true,
             "time": "2015-05-16T19:24:58+00:00"
+        },
+        {
+            "name": "aws/aws-crt-php",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/awslabs/aws-crt-php.git",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "AWS SDK Common Runtime Team",
+                    "email": "aws-sdk-common-runtime@amazon.com"
+                }
+            ],
+            "description": "AWS Common Runtime for PHP",
+            "homepage": "https://github.com/awslabs/aws-crt-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "crt",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/awslabs/aws-crt-php/issues",
+                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.7"
+            },
+            "time": "2024-10-18T22:15:13+00:00"
+        },
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.394.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "3123c895f535792857e8c2ce345ee025606d648d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/3123c895f535792857e8c2ce345ee025606d648d",
+                "reference": "3123c895f535792857e8c2ce345ee025606d648d",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-crt-php": "^1.2.3",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^7.8.2 || ^8.0",
+                "guzzlehttp/promises": "^2.0.3 || ^3.0",
+                "guzzlehttp/psr7": "^2.6.3 || ^3.0",
+                "mtdowling/jmespath.php": "^2.9.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1.0 || ^2.0",
+                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "composer/composer": "^2.7.8",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-sockets": "*",
+                "phpunit/phpunit": "^10.0",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-pcntl": "To use client-side monitoring",
+                "ext-sockets": "To use client-side monitoring"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "https://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "forum": "https://github.com/aws/aws-sdk-php/discussions",
+                "issues": "https://github.com/aws/aws-sdk-php/issues",
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.394.2"
+            },
+            "time": "2026-08-27T18:54:08+00:00"
         },
         {
             "name": "axn/laravel-laroute",
@@ -1936,6 +2087,71 @@
             "time": "2021-06-23T21:56:05+00:00"
         },
         {
+            "name": "league/flysystem-aws-s3-v3",
+            "version": "1.0.30",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-aws-s3-v3.git",
+                "reference": "af286f291ebab6877bac0c359c6c2cb017eb061d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/af286f291ebab6877bac0c359c6c2cb017eb061d",
+                "reference": "af286f291ebab6877bac0c359c6c2cb017eb061d",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.20.0",
+                "league/flysystem": "^1.0.40",
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "~1.0.1",
+                "phpspec/phpspec": "^2.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\AwsS3v3\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "Flysystem adapter for the AWS S3 SDK v3.x",
+            "support": {
+                "issues": "https://github.com/thephpleague/flysystem-aws-s3-v3/issues",
+                "source": "https://github.com/thephpleague/flysystem-aws-s3-v3/tree/1.0.30"
+            },
+            "funding": [
+                {
+                    "url": "https://offset.earth/frankdejonge",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/frankdejonge",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/flysystem",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-07-02T13:51:38+00:00"
+        },
+        {
             "name": "league/mime-type-detection",
             "version": "1.17.0",
             "source": {
@@ -2256,6 +2472,72 @@
             },
             "abandoned": "dragonmantank/cron-expression",
             "time": "2019-12-28T04:23:06+00:00"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "require-dev": {
+                "composer/xdebug-handler": "^3.0.3",
+                "phpunit/phpunit": "^8.5.52"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.9-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/JmesPath.php"
+                ],
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "support": {
+                "issues": "https://github.com/jmespath/jmespath.php/issues",
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.2"
+            },
+            "time": "2026-07-06T18:56:19+00:00"
         },
         {
             "name": "natxet/cssmin",
@@ -3651,6 +3933,77 @@
             "time": "2018-10-31T09:06:03+00:00"
         },
         {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-05T06:23:12+00:00"
+        },
+        {
             "name": "symfony/event-dispatcher",
             "version": "v3.4.18",
             "source": {
@@ -3715,6 +4068,77 @@
                 "source": "https://github.com/symfony/event-dispatcher/tree/3.4"
             },
             "time": "2018-10-30T16:50:50+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v8.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "6b2f4a0eeb28b5d74f90862592923a654bc629b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/6b2f4a0eeb28b5d74f90862592923a654bc629b3",
+                "reference": "6b2f4a0eeb28b5d74f90862592923a654bc629b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v8.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-21T12:16:08+00:00"
         },
         {
             "name": "symfony/finder",
@@ -7432,5 +7856,5 @@
         "php": ">=7.1.0"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -30,6 +30,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Persistent Storage Disk
+    |--------------------------------------------------------------------------
+    |
+    | Disk used for data that must survive redeployments and be shareable
+    | across multiple app instances: conversation attachments and user/
+    | customer avatars. Defaults to the "private" local disk, preserving
+    | today's behavior. Set to "s3" (or any other configured disk) to move
+    | this data off local disk, e.g. for horizontally-scaled deployments.
+    |
+    */
+
+    'persistent_disk' => env('PERSISTENT_DISK', 'private'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Filesystem Disks
     |--------------------------------------------------------------------------
     |
@@ -71,6 +86,10 @@ return [
             'secret' => env('AWS_SECRET_ACCESS_KEY'),
             'region' => env('AWS_DEFAULT_REGION'),
             'bucket' => env('AWS_BUCKET'),
+            'endpoint' => env('AWS_ENDPOINT'),
+            'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
+            'url' => env('AWS_URL'),
+            'visibility' => 'private',
         ],
 
     ],

--- a/routes/open.php
+++ b/routes/open.php
@@ -13,8 +13,6 @@
 
 // Download attachments
 Route::get('/storage/attachment/{dir_1}/{dir_2}/{dir_3}/{file_name}', 'OpenController@downloadAttachment')->name('attachment.download');
-// Avatar photos
-Route::get('/storage/photo/{type}/{file_name}', 'OpenController@photo')->name('photo.download');
 // Open tracking
 Route::get('/thread/read/{conversation_id}/{thread_id}/{hash}', 'OpenController@setThreadAsRead')->name('open_tracking.set_read');
 // Web Cron

--- a/routes/open.php
+++ b/routes/open.php
@@ -13,6 +13,8 @@
 
 // Download attachments
 Route::get('/storage/attachment/{dir_1}/{dir_2}/{dir_3}/{file_name}', 'OpenController@downloadAttachment')->name('attachment.download');
+// Avatar photos
+Route::get('/storage/photo/{type}/{file_name}', 'OpenController@photo')->name('photo.download');
 // Open tracking
 Route::get('/thread/read/{conversation_id}/{thread_id}/{hash}', 'OpenController@setThreadAsRead')->name('open_tracking.set_read');
 // Web Cron


### PR DESCRIPTION
Attachments and user/customer avatars are currently hardcoded to the local disk, with no way to point them at S3 (or an S3-compatible provider). This adds a `persistent_disk` config, defaulting
to today's local behavior, so both can be moved to durable/shared storage.

## Configuration

```
PERSISTENT_DISK=s3
AWS_ACCESS_KEY_ID=...
AWS_SECRET_ACCESS_KEY=...
AWS_DEFAULT_REGION=eu-central-1
AWS_BUCKET=freescout-persistent

# Only for S3-compatible non-AWS providers (MinIO, Hetzner Object Storage, ...)
AWS_ENDPOINT=
AWS_USE_PATH_STYLE_ENDPOINT=true
AWS_URL=
```

One disk for both attachments and avatars. `league/flysystem-aws-s3-v3` moved from `require-dev`
(where it already sat, unused) to `require`.

## Implementation notes

- No code assumes a local filesystem path anymore. Everywhere a real file or PHP resource is
  actually required by a third-party API (SwiftMailer attachments, GD image encoding,
  `UploadedFile`-based copy helpers), the bytes are streamed from Flysystem into a temp
  stream/file instead of relying on the disk having a native path.
- `Attachment::getLocalFilePath()` is kept for the local-disk case but no longer used at the three
  spots that broke under S3 (reply attachments, conversation-forward attachment copy, avatar
  encoding).

## Known limitation

No migration command for moving *existing* local attachments/avatars into a newly-configured
bucket - only newly-written files go through the configured disk. Existing files need a manual
copy (e.g. `aws s3 sync`) if switching an already-running instance.
