### PR TITLE
Extend Thread-Index with a child block on replies so Outlook groups them (#4922)

### DIFF
--- a/app/Jobs/SendReplyToCustomer.php
+++ b/app/Jobs/SendReplyToCustomer.php
@@ -223,7 +223,13 @@ class SendReplyToCustomer implements ShouldQueue
         if ($last_customer_thread) {
             $outloook_thread_index = $last_customer_thread->getHeader('Thread-Index');
             if (!empty($outloook_thread_index)) {
-                $headers['Thread-Index'] = $outloook_thread_index;
+                // A reply must extend the parent's conversation index with
+                // a 5-byte child block (MS-OXOMSG 2.2.1.3) rather than echo
+                // it verbatim, otherwise Outlook files the reply as a new
+                // conversation and the customer's original message is left
+                // on its own. Falls back to the verbatim copy if the value
+                // does not decode as a conversation index.
+                $headers['Thread-Index'] = self::extendThreadIndex($outloook_thread_index);
                 $outloook_thread_topic = $last_customer_thread->getHeader('Thread-Topic');
                 if ($outloook_thread_topic) {
                     $headers['Thread-Topic'] = $outloook_thread_topic;
@@ -662,5 +668,42 @@ class SendReplyToCustomer implements ShouldQueue
             }
             SendLog::log($this->last_thread->id, $this->message_id, $recipient, SendLog::MAIL_TYPE_EMAIL_TO_CUSTOMER, $status, $customer_id, null, $status_message, $smtp_queue_id);
         }
+    }
+
+    /**
+     * Append a 5-byte child block to an Outlook conversation index
+     * (Thread-Index header, MS-OXOMSG 2.2.1.3) so the reply nests under the
+     * customer's message instead of being read by Outlook as a new
+     * conversation. Header = 0x01 + 5 bytes of FILETIME (bits 16-55) + 16-byte
+     * GUID; each child = code(1 bit) + time delta(31) + random(4) + sequence(4).
+     * Returns the input unchanged when it does not decode as a valid index.
+     * https://github.com/freescout-help-desk/freescout/issues/4922
+     */
+    public static function extendThreadIndex($thread_index)
+    {
+        $raw = base64_decode(trim((string)$thread_index), true);
+        if ($raw === false || strlen($raw) < 22 || (strlen($raw) - 22) % 5 !== 0) {
+            return $thread_index;
+        }
+        // Header timestamp: FILETIME bits 16-55, big-endian, in bytes 1-5.
+        $hdr = unpack('Nhi/Clo', substr($raw, 1, 5));
+        $hdr_bits = ($hdr['hi'] << 8) | $hdr['lo'];
+        $now_ft = (int) round((microtime(true) + 11644473600) * 10000000);
+        $now_bits = ($now_ft >> 16) & 0xFFFFFFFFFF;
+        $delta = ($now_bits - $hdr_bits) << 16;
+        if ($delta < 0) {
+            $delta = 0;
+        }
+        $code = 0;
+        $diff = $delta >> 18;
+        if ($diff > 0x7FFFFFFF) {
+            $code = 1;
+            $diff = min($delta >> 23, 0x7FFFFFFF);
+        }
+        // 40-bit child block: code(1) | diff(31) | random(4) | sequence(4)=0
+        $block = (($code << 39) | ($diff << 8) | (random_int(0, 15) << 4)) & 0xFFFFFFFFFF;
+        $bytes = pack('C5', ($block >> 32) & 0xFF, ($block >> 24) & 0xFF, ($block >> 16) & 0xFF, ($block >> 8) & 0xFF, $block & 0xFF);
+
+        return base64_encode($raw.$bytes);
     }
 }


### PR DESCRIPTION
Fixes #4922 (the remaining half of it).

## Problem

Outlook desktop groups messages into conversations by the `Thread-Index` header, not by `In-Reply-To` / `References`. Since #4922 FreeScout copies the customer's `Thread-Index` back onto the reply, but it copies it **verbatim**. Per MS-OXOMSG 2.2.1.3 a reply must *extend* the parent's index with a 5-byte child block. Outlook does not treat an identical index as a reply, so it opens a new conversation for the FreeScout message. The customer's original email is left on its own and everything after it lands in a second conversation.

Observed on a customer running Outlook 16.0 over Gmail IMAP ("why are your replies not attached to my original email"). Every reply she sent after the first carried a different 22-byte conversation root from her original, which is the signature of the split.

## Change

- `SendReplyToCustomer::extendThreadIndex()` appends a child block: code bit + 31-bit time delta from the header timestamp + 4 random bits + 4-bit sequence, as Outlook itself does.
- Called where `Thread-Index` is already set. Behaviour is unchanged for customers whose mail carried no `Thread-Index` (Gmail, Apple Mail, Thunderbird): no header is added.
- Returns the input unchanged if it does not base64-decode to a valid index (22 + 5n bytes), so the worst case is the current behaviour.

## Testing

- Unit: a real Outlook 22-byte header extends to 27 bytes with the same root and a correct time delta; a 37-byte header (already carrying child blocks) extends to 42; garbage and short inputs pass through unchanged.
- Live, both directions: a reply to a message carrying `Thread-Index` went out with parent + 5 bytes and still threaded correctly in Gmail (In-Reply-To / References intact). A reply to a message without the header went out with no `Thread-Index`, identical to before.
- `php -l` clean on PHP 8.3.
