### PR TITLE
Drop the dead $uri self-assignment in the laroute override

### DIFF
--- a/overrides/lord/laroute/src/Routes/Collection.php
+++ b/overrides/lord/laroute/src/Routes/Collection.php
@@ -71,7 +71,6 @@ class Collection extends \Illuminate\Support\Collection
         
         $host    = $route->domain();
         $methods = $route->methods();
-        $uri     = $uri;
         $name    = $route->getName();
         $action  = $route->getActionName();
         $laroute = array_get($route->getAction(), 'laroute', null);


### PR DESCRIPTION
Upstream laroute reads the uri right here, and the override moved that read ten lines up so the subdirectory can be cut off it. The line left behind assigns $uri to itself, so it does nothing, and it reads as if something still happened to the uri at that point.
