### PR TITLE
Preserve native CSS custom properties during minification

### DIFF
--- a/overrides/natxet/cssmin/src/CssMin.php
+++ b/overrides/natxet/cssmin/src/CssMin.php
@@ -592,6 +592,12 @@ class CssVariablesMinifierPlugin extends aCssMinifierPlugin
 			for ($i = 0, $l = count($m[0]); $i < $l; $i++)
 			{
 				$variable	= trim($m[1][$i]);
+				// Native CSS custom properties are resolved by the browser and must
+				// not be treated as variables from CssMin's @variables syntax.
+				if (substr($variable, 0, 2) === "--")
+				{
+					continue;
+				}
 				foreach ($mediaTypes as $mediaType)
 				{
 					if (isset($this->variables[$mediaType], $this->variables[$mediaType][$variable]))

--- a/tests/Unit/CssMinTest.php
+++ b/tests/Unit/CssMinTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+class CssMinTest extends TestCase
+{
+    public function testNativeCssCustomPropertiesArePreserved()
+    {
+        $css = ':root { --sidebar-width: 360px; } .sidebar { width: var(--sidebar-width); }';
+
+        $this->assertSame(
+            ':root{--sidebar-width:360px}.sidebar{width:var(--sidebar-width)}',
+            \CssMin::minify($css)
+        );
+    }
+
+    public function testNativeCssCustomPropertiesInsideClampArePreserved()
+    {
+        $css = '.sidebar { width: clamp(280px, 25vw, var(--sidebar-width)); }';
+
+        $this->assertSame(
+            '.sidebar{width:clamp(280px, 25vw, var(--sidebar-width))}',
+            \CssMin::minify($css)
+        );
+    }
+
+    public function testLegacyCssMinVariablesAreStillResolved()
+    {
+        $css = '@variables { sidebarWidth: 360px; } .sidebar { width: var(sidebarWidth); }';
+
+        $this->assertSame('.sidebar{width:360px}', \CssMin::minify($css));
+    }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> #5613 is the better fix for this, IMHO, but this is the smallest possible. 

Fixes #5610.

This change preserves browser-native CSS custom-property references during stylesheet minification. Values beginning with `--` are left for the browser to resolve, while CssMin's existing `@variables` syntax continues to work unchanged.

Regression tests cover:

- a native `var(--name)` reference;
- `var(--name)` nested inside `clamp()`;
- the existing legacy `@variables` behavior.

Tested with:

```text
vendor/bin/phpunit tests/Unit/CssMinTest.php
OK (3 tests, 3 assertions)
```
