### PR TITLE
Keep CRLF header separators in MailTransport so mail() output stays valid MIME

### DIFF
--- a/overrides/swiftmailer/swiftmailer/lib/classes/Swift/Transport/MailTransport.php
+++ b/overrides/swiftmailer/swiftmailer/lib/classes/Swift/Transport/MailTransport.php
@@ -157,7 +157,15 @@ class Swift_Transport_MailTransport implements Swift_Transport
 
         if ("\r\n" != PHP_EOL) {
             // Non-windows (not using SMTP)
-            $headers = str_replace("\r\n", PHP_EOL, $headers);
+            // Do NOT convert CRLF to LF in $headers: mail() emits the To:
+            // and Subject: headers it builds from $to/$subject using CRLF,
+            // so rewriting the remaining headers to bare LF yields a mix of
+            // both endings. Exim (and other MTAs) then read an LF-separated
+            // line as an obs-fold continuation of the previous header and
+            // prepend a space, which demotes Content-Type: multipart/... to
+            // a folded part of Message-ID:. The message loses its MIME type
+            // and clients render the raw source (boundaries, quoted-printable)
+            // instead of the body. See RFC 5322 2.2 and PHP >= 7.2 mail().
             $subject = str_replace("\r\n", PHP_EOL, $subject);
             $body = str_replace("\r\n", PHP_EOL, $body);
         } else {


### PR DESCRIPTION
### Problem

With the **`mail`** driver (`Mailbox` → *PHP mail*), outgoing messages can reach the recipient as **raw MIME source** instead of a rendered message. The user sees boundaries, `Content-Type:` lines and quoted-printable escapes as message text:

```
--_=_swift_1788449502_49b1670c4cccece2778ac1e24773fce4_=_
Content-Type: text/plain; charset=utf-8
Content-Transfer-Encoding: quoted-printable

teste
=C5=9B=C5=9B=C4=85=C5=9B
```

It looks like a charset/encoding bug, but the MIME produced by SwiftMailer is perfectly valid — the message is corrupted on the way to the MTA.

### Root cause

`Swift_Transport_MailTransport::send()` rewrites every CRLF in `$headers` to `PHP_EOL` (bare `LF` on Linux) before calling `mail()`:

```php
$headers = str_replace("\r\n", PHP_EOL, $headers);
```

But PHP builds the `To:` and `Subject:` headers itself from the `$to`/`$subject` arguments and **emits them with CRLF**. Verified on PHP 8.4.24 by capturing what `mail()` hands to `sendmail_path`:

```
CRLF  |To: probe@example.com|      <- added by PHP
CRLF  |Subject: PROBE-SUBJ|        <- added by PHP
CRLF  |X-Test-A: aaa|              <- from $headers (last line keeps its ending)
LF    |X-Test-B: bbb|
```

So the header block reaches the MTA with **mixed line endings**. Exim (and other MTAs) treat an LF-separated line as an [obs-fold](https://datatracker.ietf.org/doc/html/rfc5322#section-4.2) continuation of the previous header and prepend a space. The delivered message becomes:

```
Message-ID: <...>
 Date: Thu, 03 Sep 2026 18:07:36 +0200
 From: FreeScout Test <development@itdesk.eu>
 MIME-Version: 1.0
 Content-Type: multipart/alternative;
  boundary="_=_swift_..."
```

`Content-Type` is no longer a header — it is a folded part of `Message-ID`. The message loses its MIME type, so clients fall back to rendering the raw body.

### Why it is the *mix* that breaks it, not LF itself

Feeding Exim the same message three ways (bypassing PHP entirely) isolates the cause:

| Variant | `Content-Type` survives as a header | Folded headers |
|---|---|---|
| all headers `LF` | yes | 0 |
| all headers `CRLF` | yes | 0 |
| **`To:`/`Subject:` CRLF + rest LF** (what `mail()` produces today) | **no** | **4** |

### Fix

Leave `$headers` untouched so the CRLF separators required by RFC 5322 — and already used by `mail()` for `To:`/`Subject:` — stay consistent. `$subject` and `$body` keep the existing `PHP_EOL` conversion, so this is a one-line functional change.

### Verification

FreeScout 1.8.238 · PHP 8.4.24 · Exim 4.100 · CloudLinux/CageFS · `out_method=1` (PHP mail). Messages delivered to a real local mailbox and inspected as received:

| | before | after |
|---|---|---|
| `^Content-Type: multipart/alternative` present | **0** | **1** |
| folded headers (`^ (Date\|From\|MIME-Version\|Content-Type):`) | **4** | **0** |

Also checked after the fix:

- full production path (REST API → queue worker → `mail()`) delivers a correctly structured `multipart/alternative` message;
- quoted-printable UTF-8 body decodes correctly (Polish diacritics: `śśąś`, `Paść`, `Zażółć gęślą jaźń`);
- long subjects that SwiftMailer folds across multiple lines still decode correctly and do not reintroduce folding;
- `App\SendLog` status `1`, no failed jobs, `laravel.log` clean.

The `smtp` and `sendmail` transports are untouched, as is the Windows branch of this `if`.
