### PR TITLE
Retry transient IMAP connection failures

### DIFF
--- a/app/Console/Commands/FetchEmails.php
+++ b/app/Console/Commands/FetchEmails.php
@@ -140,7 +140,9 @@ class FetchEmails extends Command
                 // (when there are many mailboxes for example),
                 // we increase connection sleep time and retry after sleep.
                 // https://github.com/freescout-help-desk/freescout/issues/4227
-                if (\Str::startsWith($e->getMessage(), 'connection setup failed')) {
+                if (\Str::startsWith($e->getMessage(), 'connection setup failed')
+                    || \Str::startsWith($e->getMessage(), 'connection failed')
+                ) {
                     $sleep += 500000;
 
                     usleep(self::MAX_SLEEP);


### PR DESCRIPTION
## What changed

Treat Webklex transport errors starting with `connection failed` as eligible for the same single delayed retry FreeScout already applies to `connection setup failed` errors.

## Why

FreeScout 1.8.239 currently retries `connection setup failed...`, but Webklex can wrap lower-level socket/TLS failures as:

`connection failed - stream_socket_client(): SSL operation failed ...`

Those errors currently bypass the existing retry path and are logged immediately, even when the failure is intermittent and the next fetch succeeds.

Issue #5623 reports this exact behavior with Microsoft 365 IMAP (`outlook.office365.com:993`, SSL) on FreeScout 1.8.239.

The existing retry path was introduced for transient connection failures in #4227 and was later broadened for connection-error text in #5584.

This change does not alter TLS settings, certificate validation, retry count, or retry delay. A persistent failure is still logged when the existing retry also fails.

Related: #5623
Related: #5584
Related: #4227
