### PR TITLE
Add plain text paste option for conversation editor

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -238,6 +238,104 @@ var EditorRemoveFormatButton = function (context) {
 	return button.render();   // return button as jquery object
 }
 
+function editorPlainTextPasteStorageKey()
+{
+	var user_id = getGlobalAttr('auth_user_id');
+
+	if (!user_id) {
+		return '';
+	}
+
+	return 'editor_plain_text_paste_'+user_id;
+}
+
+function editorPlainTextPasteEnabled()
+{
+	var key = editorPlainTextPasteStorageKey();
+
+	if (!key) {
+		return false;
+	}
+
+	return localStorageGet(key) == '1';
+}
+
+function editorPlainTextPasteSet(enabled)
+{
+	var key = editorPlainTextPasteStorageKey();
+
+	if (!key) {
+		return;
+	}
+
+	if (enabled) {
+		localStorageSet(key, '1');
+	} else {
+		localStorageRemove(key);
+	}
+}
+
+var EditorRemoveFormatPasteButton = function (context) {
+	if (convIsChat()) {
+		return EditorRemoveFormatButton(context);
+	}
+
+	var ui = $.summernote.ui;
+	var plain_text_enabled = editorPlainTextPasteEnabled();
+
+	var button = ui.buttonGroup([
+		ui.button({
+			contents: '<i class="note-icon-close"></i>',
+			tooltip: Lang.get("messages.remove_format"),
+			container: 'body',
+			click: function () {
+				context.invoke('removeFormat');
+			}
+		}),
+		ui.button({
+			className: 'dropdown-toggle',
+			contents: '<span class="caret"></span>',
+			tooltip: Lang.get("messages.paste_as_plain_text"),
+			container: 'body',
+			data: {
+				toggle: 'dropdown'
+			}
+		}),
+		ui.dropdown([
+			ui.button({
+				className: 'editor-plain-text-paste-toggle',
+				contents: '<span class="editor-plain-text-paste-state">'+(plain_text_enabled ? '&#9745;' : '&#9744;')+'</span> '+htmlEscape(Lang.get("messages.paste_as_plain_text")),
+				click: function (e) {
+					var enabled = !editorPlainTextPasteEnabled();
+					editorPlainTextPasteSet(enabled);
+					$(e.currentTarget).find('.editor-plain-text-paste-state:first').html(enabled ? '&#9745;' : '&#9744;');
+				}
+			})
+		])
+	]);
+
+	return button.render();
+}
+
+function editorConversationToolbar(toolbar)
+{
+	var result = [];
+
+	for (var group_i = 0; group_i < toolbar.length; group_i++) {
+		var buttons = toolbar[group_i][1].slice(0);
+
+		for (var button_i = 0; button_i < buttons.length; button_i++) {
+			if (buttons[button_i] == 'removeformat') {
+				buttons[button_i] = 'removeformatpaste';
+			}
+		}
+
+		result.push([toolbar[group_i][0], buttons]);
+	}
+
+	return result;
+}
+
 var EditorListsButton = function (context) {
 	var ui = $.summernote.ui;
 
@@ -1765,6 +1863,7 @@ function convEditorInit()
 	    savedraft: EditorSaveDraftButton,
 	    discard: EditorDiscardButton,
 	    removeformat: EditorRemoveFormatButton,
+	    removeformatpaste: EditorRemoveFormatPasteButton,
 	    lists: EditorListsButton
 	});
 
@@ -1775,7 +1874,7 @@ function convEditorInit()
 		dialogsFade: true,
 		disableResizeEditor: true,
 		followingToolbar: false,
-		toolbar: fsApplyFilter('conversation.editor_toolbar', fs_conv_editor_toolbar),
+		toolbar: editorConversationToolbar(fsApplyFilter('conversation.editor_toolbar', fs_conv_editor_toolbar)),
 		buttons: fs_conv_editor_buttons,
 		// Disable inserting HR tag.
 		// https://github.com/freescout-help-desk/freescout/issues/4909
@@ -1811,14 +1910,15 @@ function convEditorInit()
 	    }
 	};
 
-	// Allow to insert only plain text in chats
-	if (convIsChat()) {
-		options.callbacks.onPaste = function (e) {
-	        var bufferText = ((e.originalEvent || e).clipboardData || window.clipboardData).getData('Text');
-	        e.preventDefault();
-	        document.execCommand('insertText', false, bufferText);
-	    };
-	}
+	// Allow plain-text paste in chats and when enabled by the user.
+	options.callbacks.onPaste = function (e) {
+		if (!convIsChat() && !editorPlainTextPasteEnabled()) {
+			return;
+		}
+		var bufferText = ((e.originalEvent || e).clipboardData || window.clipboardData).getData('Text');
+		e.preventDefault();
+		document.execCommand('insertText', false, bufferText);
+	};
 
 	options = fsApplyFilter('editor.options', options);
 

--- a/resources/views/js/vars.blade.php
+++ b/resources/views/js/vars.blade.php
@@ -73,6 +73,7 @@ var LangMessages = {
             "confirm_delete_module": "{{ __("Delete this module?") }}",
             "confirm_update": "{{ __("Please backup application files and database before you continue.") }}",
             "remove_format": "{{ __("Remove Formatting") }}",
+            "paste_as_plain_text": "{{ __("Paste as Plain Text") }}",
             "list": "{{ __("List") }}",
             "add_lower": "{{ __("add") }}",
             "user_viewing": "{{ __(":user is viewing") }}",


### PR DESCRIPTION
## What changed

Add a General setting, disabled by default, that makes pasted content in the conversation editor use plain text.

When enabled, email replies and new conversations reuse the same plain-text `onPaste` handling that FreeScout already applies to chat conversations.

## Why

Pasting content from Word, Outlook, Google Docs, and other rich editors can copy source HTML and styling into replies. Summernote's Remove Formatting command does not reliably remove styles attached to surrounding block elements.

The new option lets administrators enforce plain-text paste for the conversation editor without changing behavior for existing installations.

## Behavior

* Disabled by default.
* Chat conversations keep their existing plain-text paste behavior.
* When enabled, conversation-editor paste inserts clipboard text only.
* Images and other rich clipboard content are not pasted while the option is enabled.
* No database migration is required; the setting uses the existing options storage.
* The setting value is validated as boolean before saving.

## Checks

* `php -l app/Http/Controllers/SettingsController.php`
* `git diff --check`

Fixes #5599
Related: #1672
Related: #2063
