### PR TITLE
Use user timezone in text notifications

### DIFF
--- a/resources/views/emails/user/notification_text.blade.php
+++ b/resources/views/emails/user/notification_text.blade.php
@@ -7,11 +7,11 @@
 @foreach ($threads as $thread)
 -----------------------------------------------------------
 @if ($thread->type == App\Thread::TYPE_LINEITEM)
-## {{ $thread->getActionText('', true, false, $user, view('emails/user/thread_by', ['thread' => $thread, 'user' => $user])->render()) }}, {{ __('on :date', ['date' => App\Customer::dateFormat($thread->created_at, 'M j @ H:i').' ('.\Config::get('app.timezone').')' ]) }}
+## {{ $thread->getActionText('', true, false, $user, view('emails/user/thread_by', ['thread' => $thread, 'user' => $user])->render()) }}, {{ __('on :date', ['date' => App\User::dateFormat($thread->created_at, 'M j @ H:i', $user).' ('.$user->timezone.')' ]) }}
 @else
 @if ($thread->type == App\Thread::TYPE_NOTE)
-## {{ __(':person added a note', ['person' => $thread->getCreatedBy()->getFullName(true)]) }}, {{ __('on :date', ['date' => App\Customer::dateFormat($thread->created_at, 'M j @ H:i').' ('.\Config::get('app.timezone').')' ]) }}@else
-## @if ($thread->isForwarded()){{ __(':person forwarded a conversation :forward_parent_conversation_number', ['person' => $thread->getCreatedBy()->getFullName(true), 'forward_parent_conversation_number' => '#'.$thread->getMetaFw(App\Thread::META_FORWARD_PARENT_CONVERSATION_NUMBER)]) }}@elseif ($loop->last){{ __(':person started the conversation', ['person' => $thread->getCreatedBy()->getFullName(true)]) }}@else{{ __(':person replied', ['person' => $thread->getCreatedBy()->getFullName(true)]) }}@endif, {{ __('on :date', ['date' => App\Customer::dateFormat($thread->created_at, 'M j @ H:i').' ('.\Config::get('app.timezone').')' ]) }}@endif:
+## {{ __(':person added a note', ['person' => $thread->getCreatedBy()->getFullName(true)]) }}, {{ __('on :date', ['date' => App\User::dateFormat($thread->created_at, 'M j @ H:i', $user).' ('.$user->timezone.')' ]) }}@else
+## @if ($thread->isForwarded()){{ __(':person forwarded a conversation :forward_parent_conversation_number', ['person' => $thread->getCreatedBy()->getFullName(true), 'forward_parent_conversation_number' => '#'.$thread->getMetaFw(App\Thread::META_FORWARD_PARENT_CONVERSATION_NUMBER)]) }}@elseif ($loop->last){{ __(':person started the conversation', ['person' => $thread->getCreatedBy()->getFullName(true)]) }}@else{{ __(':person replied', ['person' => $thread->getCreatedBy()->getFullName(true)]) }}@endif, {{ __('on :date', ['date' => App\User::dateFormat($thread->created_at, 'M j @ H:i', $user).' ('.$user->timezone.')' ]) }}@endif:
 @if ($thread->isForward()){{ __(':person forwarded this conversation. Forwarded conversation: :forward_child_conversation_number', ['person' => ucfirst($thread->getForwardByFullName()),'forward_child_conversation_number' => '#'.$thread->getMetaFw(App\Thread::META_FORWARD_CHILD_CONVERSATION_NUMBER)]) }}
 @endif{{ (new Html2Text\Html2Text($thread->body))->getText() }}
 @endif


### PR DESCRIPTION
## What changed

Plain-text user notification emails now format thread timestamps using the recipient's timezone and 12/24-hour time preference, matching the HTML notification.

Previously, `notification_text.blade.php` used `App\Customer::dateFormat()` and appended the global application timezone. As a result, email clients displaying the `text/plain` MIME part could show a different time from the timezone configured in the recipient's FreeScout profile.

The three notification timestamp occurrences now use `App\User::dateFormat(..., $user)` and display the recipient's timezone.

## Checks

* `git diff --check`
* Verified all 3 text-notification timestamps use `App\User::dateFormat(..., $user)`
* Verified no `App\Customer::dateFormat()` timestamp usage remains in the template
* Verified the global application timezone is no longer used for these timestamps
* Compiled the Blade template successfully
* `php -l` passed on the compiled template

Fixes #5570
