### PR TITLE
Fix "Show Original" on IMAP servers which reject searching by Message-ID

### DIFF
--- a/app/Misc/Mail.php
+++ b/app/Misc/Mail.php
@@ -65,6 +65,12 @@ class Mail
     const OAUTH_GOOGLE_SMTP = 'smtp.gmail.com';
 
     /**
+     * Number of messages to fetch the headers of at a time
+     * when scanning a folder in findMessageByHeaders().
+     */
+    const SCAN_CHUNK_SIZE = 50;
+
+    /**
      * If reply is not extracted properly from the incoming email, add here a new separator.
      * Order is not important.
      * Idially separators must contain < or > to avoid false positives.
@@ -157,7 +163,7 @@ class Mail
      * @param App\User $user_from
      * @param App\Conversation $conversation
      */
-    public static function setMailDriver($mailbox = null, $user_from = null, $conversation = null, $thread = null)
+    public static function setMailDriver($mailbox = null, $user_from = null, $conversation = null)
     {
         if ($mailbox) {
             // Configure mail driver according to Mailbox settings.
@@ -192,7 +198,7 @@ class Mail
             }
 
             \Config::set('mail.driver', $mailbox->getMailDriverName());
-            \Config::set('mail.from', $mailbox->getMailFrom($user_from, $conversation, $thread));
+            \Config::set('mail.from', $mailbox->getMailFrom($user_from, $conversation));
 
             // SMTP.
             if ($mailbox->out_method == Mailbox::OUT_METHOD_SMTP) {
@@ -924,9 +930,8 @@ class Mail
 
                 // Limit using date to speed up the search.
                 if ($message_date) {
-                    $query->since($message_date->subDays(7));
-                    // Here we should add 14 days, as previous line subtracts 7 days.
-                    $query->before($message_date->addDays(14));
+                    $query->since($message_date->copy()->subDays(7));
+                    $query->before($message_date->copy()->addDays(7));
                 }
 
                 if ($no_charset) {
@@ -946,8 +951,8 @@ class Mail
                     //$query = $folder->query()->text('<'.$message_id.'>')->leaveUnread()->limit(1)->setCharset(null);
                     $query = $folder->query()->whereMessageId('"<'.$search_message_id.'>"')->leaveUnread()->limit(1)->setCharset(null);
                     if ($message_date) {
-                        $query->since($message_date->subDays(7));
-                        $query->before($message_date->addDays(14));
+                        $query->since($message_date->copy()->subDays(7));
+                        $query->before($message_date->copy()->addDays(7));
                     }
                     $messages = $query->get();
                     $no_charset = true;
@@ -962,7 +967,117 @@ class Mail
             }
         }
 
+        return self::findMessageByHeaders($mailbox, $client, $imap_folders, $message_id, $message_date);
+    }
+
+    /**
+     * Find an IMAP message by Message-ID without using IMAP search.
+     *
+     * Some IMAP servers don't return search results by Message-ID: imap.yandex.ru
+     * for example responds with "NO [UNAVAILABLE] UID SEARCH Backend error".
+     * For those we fetch the headers of the messages received around the date of
+     * the message and compare Message-IDs locally.
+     */
+    public static function findMessageByHeaders($mailbox, $client, $imap_folders, $message_id, $message_date)
+    {
+        // Without a date we would have to scan the whole mailbox.
+        if (!$message_date) {
+            return null;
+        }
+
+        $limit = (int) \Eventy::filter('mail.fetch_message.scan_limit', 500, $mailbox);
+
+        if ($limit <= 0) {
+            return null;
+        }
+
+        $message_id = trim($message_id);
+
+        // IMAP searches by INTERNALDATE which may differ from the date in the
+        // headers, so if the message is not found on its own date, try the
+        // neighbouring days too.
+        $date_ranges = [
+            [$message_date->copy(), $message_date->copy()->addDay()],
+            [$message_date->copy()->subDay(), $message_date->copy()->addDays(2)],
+        ];
+
+        $connection = $client->getConnection();
+
+        foreach ($imap_folders as $folder_name) {
+            try {
+                $folder = self::getImapFolder($client, $folder_name);
+
+                if (!$folder) {
+                    continue;
+                }
+
+                $limit_reached = false;
+
+                foreach ($date_ranges as $date_range) {
+                    $client->openFolder($folder->path);
+
+                    $uids = array_values($connection->search([
+                        'SINCE "'.$date_range[0]->format('d-M-Y').'"'
+                        .' BEFORE "'.$date_range[1]->format('d-M-Y').'"'
+                    ]));
+
+                    // Calling the protocol directly here, so the server response
+                    // has to be checked here as well.
+                    if (!count($uids)
+                        && method_exists($connection, 'getLastError')
+                        && $connection->getLastError()
+                    ) {
+                        \Log::error('('.$mailbox->name.') Show Original - IMAP search rejected by the server'
+                            .' in "'.$folder_name.'"; server response: '.$connection->getLastError());
+                    }
+
+                    if (count($uids) > $limit) {
+                        $uids = array_slice($uids, 0, $limit);
+                        $limit_reached = true;
+                    }
+
+                    // Fetching the headers only and in chunks, to stop as soon as
+                    // the message is found. Note that fetching RFC822.HEADER does
+                    // not set the \Seen flag.
+                    foreach (array_chunk($uids, self::SCAN_CHUNK_SIZE) as $uids_chunk) {
+                        $headers = $connection->headers($uids_chunk);
+
+                        foreach ($headers as $uid => $header) {
+                            if (self::getMessageIdFromHeaders($header) != $message_id) {
+                                continue;
+                            }
+
+                            return $folder->query()->leaveUnread()->getMessageByUid($uid);
+                        }
+                    }
+                }
+
+                if ($limit_reached) {
+                    \Log::error('('.$mailbox->name.') Show Original - the number of messages to scan in "'
+                        .$folder_name.'" exceeds the limit ('.$limit.'), message not found: '.$message_id);
+                }
+            } catch (\Exception $e) {
+                \Helper::logException($e, '('.$mailbox->name.') Could not find specific message by Message-ID in headers:');
+            }
+        }
+
         return null;
+    }
+
+    /**
+     * Get the value of the Message-ID header from a raw headers string.
+     * Parsing just this one header, as parsing them all is expensive
+     * when scanning a lot of messages.
+     */
+    public static function getMessageIdFromHeaders($headers_str)
+    {
+        if (!preg_match('/^Message\-ID\s*:((?:[^\r\n]|\r?\n[ \t])*)/im', $headers_str ?? '', $m)) {
+            return '';
+        }
+
+        // Message-ID can't contain spaces, so it's safe to remove them
+        // along with the line folding.
+        return str_replace(['<', '>', "\r", "\n", "\t", ' '], '', $m[1]);
     }
 
     public static function oauthGetAuthorizationUrl($provider_code, $params)

--- a/overrides/webklex/php-imap/src/Connection/Protocols/ImapProtocol.php
+++ b/overrides/webklex/php-imap/src/Connection/Protocols/ImapProtocol.php
@@ -45,6 +45,12 @@ class ImapProtocol extends Protocol {
     public static $last_connected_check = 0;
 
     /**
+     * Last NO/BAD/BYE response received from the server.
+     * @var string
+     */
+    public static $last_error = '';
+
+    /**
      * Imap constructor.
      * @param bool $cert_validation set to false to skip SSL certificate validation
      * @param mixed $encryption Connection encryption method
@@ -171,6 +177,15 @@ class ImapProtocol extends Protocol {
 
     public static function getDebugLog() {
         return self::$debug_log;
+    }
+
+    /**
+     * Get the last NO/BAD/BYE response received from the server.
+     * It is reset on every readResponse() call, so it has to be read
+     * right after the request which is being checked.
+     */
+    public static function getLastError() {
+        return self::$last_error;
     }
 
     /**
@@ -329,6 +344,9 @@ class ImapProtocol extends Protocol {
     public function readResponse(string $tag, bool $dontParse = false) {
         $lines = [];
         $tokens = null; // define $tokens variable before first use
+
+        self::$last_error = '';
+
         do {
             $readAll = $this->readLine($tokens, $tag, $dontParse);
             $lines[] = $tokens;
@@ -343,6 +361,13 @@ class ImapProtocol extends Protocol {
         if ($tokens[0] == 'OK') {
             return $lines ? $lines : true;
         } elseif ($tokens[0] == 'NO' || $tokens[0] == 'BAD' || $tokens[0] == 'BYE') {
+            // Remember the response, otherwise it's lost completely: callers
+            // receive just "false" and can't tell a rejected command from an
+            // empty result.
+            self::$last_error = trim(implode(' ', array_filter($tokens, function ($token) {
+                return is_scalar($token);
+            })));
+
             return false;
         }
 

--- a/overrides/webklex/php-imap/src/Query/Query.php
+++ b/overrides/webklex/php-imap/src/Query/Query.php
@@ -192,7 +192,26 @@ class Query {
         $this->generate_query();
 
         try {
-            $available_messages = $this->client->getConnection()->search([$this->getRawQuery()], $this->sequence);
+            $connection = $this->client->getConnection();
+
+            $available_messages = $connection->search([$this->getRawQuery()], $this->sequence);
+
+            // A NO/BAD/BYE response is turned into an empty result by the protocol,
+            // so without this a rejected or unsupported search command looks exactly
+            // like "nothing found".
+            if (!count($available_messages)
+                && method_exists($connection, 'getLastError')
+                && $connection->getLastError()
+            ) {
+                // Not using the words "failed", "error" etc. followed by a colon
+                // here: the log viewer treats them as log levels and shows the
+                // same record twice.
+                \Log::error('IMAP search rejected by the server. This is not necessarily a problem'
+                    .' - where possible FreeScout falls back to finding the message by other means,'
+                    .' by scanning message headers for example. Search query: '.$this->getRawQuery()
+                    .'; server response: '.$connection->getLastError());
+            }
+
             return new Collection($available_messages);
         } catch (RuntimeException $e) {
             throw new GetMessagesFailedException("failed to fetch messages", 0, $e);


### PR DESCRIPTION
Follow-up to the investigation above. This makes "Show Original" work on mailboxes whose IMAP server doesn't answer a Message-ID search, and stops the server's own error responses from being thrown away.

Three changes, easy to split if you'd rather take them one at a time.

### Corrected diagnosis

My earlier comment said Yandex "doesn't support" searching by Message-ID. That was wrong, and change (1) is what corrected it. The server does answer — it just answers with an error:

```
NO [UNAVAILABLE] UID SEARCH Backend error. sc=X6VOaF0So4Y0_2026-09-12-17-06_imap-production-main-755
```

That response was being converted into an empty result set on the way back, so `fetchMessage()` could not tell it apart from "no message matched", and nothing was logged. Hence the original report of a silent failure.

### 1. Don't discard `NO` / `BAD` / `BYE` responses

`ImapProtocol::readResponse()` returned a bare `false` for a rejected command, and `Query::search()` turned that into an empty result. "The server refused the command" and "nothing matched" were indistinguishable, and neither reached the log.

* `ImapProtocol` now stores the failing response in `self::$last_error`, exposed via `ImapProtocol::getLastError()`. It is reset at the start of every `readResponse()`, so it always refers to the request that has just been made.
* `Query::search()` logs it, but only when the search returned nothing **and** the server actually reported an error.

Behaviour is unchanged — `search()` still returns an empty collection, it is just no longer silent. `LegacyProtocol` and `PopProtocol` don't have `getLastError()`, and the `method_exists()` guard leaves them untouched.

Two things worth knowing about that log line:

* **It is logged at `error` level on purpose.** `config/app.php` defaults `log_level` to `error`, so a `warning` would never reach `laravel.log` at all — which would put us straight back to the silent failure this change exists to fix.
* **The wording avoids "failed:", "error:" and the like.** The log viewer checks each line against every level name in turn, with no `break`:

  ```php
  foreach ($this->level->all() as $level) {
      if (strpos(strtolower($h[$i]), '.' . $level) || strpos(strtolower($h[$i]), $level . ':')) {
  ```

  My first version of the message read `IMAP search failed: ...`, which matched both `.error` and `failed:` and showed every record twice, the second time with an empty environment column. Worth keeping in mind for any log message, not just this one.

Since the rejection is recoverable in the "Show Original" path, the message says so rather than reading as a hard failure. It says "where possible" rather than promising a fallback, because `Query::search()` is also reached from `FetchEmails`, where a rejected search is a real problem.

### 2. Fall back to matching Message-IDs in the headers

New `MailHelper::findMessageByHeaders()`, called from `fetchMessage()` exactly where it previously did `return null` — so it only runs once the Message-ID search has already come back empty, and never runs at all on servers where that search works.

It searches the folder by date, fetches the raw headers of the messages found, compares Message-IDs in PHP, and returns the match via `getMessageByUid()`.

Notes on the details:

* **It deliberately does not use `Query::get()`.** Doing so builds a full `Message` object per message — MIME decoding, address parsing, date parsing — just to read one header field. On a day with 143 messages that alone took about 12 s. Fetching the raw headers with `$connection->headers()` and pulling out the Message-ID with `getMessageIdFromHeaders()` costs 0 ms of PHP time by comparison.
* **Two date windows** — first the day of the message itself, then ±1 day. IMAP filters on `INTERNALDATE`, which can be a day off from the `Date` header because of time zones.
* **Nothing is marked as read.** `RFC822.HEADER` is functionally `BODY.PEEK[HEADER]` per RFC 3501, so the scan sets no `\Seen` flag, and the final `getMessageByUid()` goes through `leaveUnread()`.
* **500 messages per folder**, adjustable through a new `mail.fetch_message.scan_limit` filter, in the same spirit as the existing `mail.fetch_message.imap_folders`. Headers are fetched in chunks of 50 so the scan can stop as soon as the message is found and memory stays bounded. If the limit is hit and the message still isn't found, that's logged.
* Because the protocol is called directly here, the server response is checked here as well — otherwise a rejected date search would be silent again, which is the exact problem change (1) fixes.
* Skipped entirely when no message date is available — otherwise it would mean scanning the whole mailbox. In practice that is the second `fetchMessage()` call in `Thread::fetchBody()`, so the scan never runs twice.

### 3. Stop the date window from drifting (drive-by fix)

```php
$query->since($message_date->subDays(7));
// Here we should add 14 days, as previous line subtracts 7 days.
$query->before($message_date->addDays(14));
```

Carbon is mutable, so each iteration moved `$message_date` 7 days forward. With a single IMAP folder this is invisible, but for a mailbox configured with several folders the second folder is searched over `date+0 … date+14`, the third over `date+7 … date+21`, and so on — so the message can effectively only be found in the first folder.

Replaced with `->copy()` in both places, which also makes the intent explicit and removes the need for the comment. The fallback in (2) needs an unmutated date as well.

### Not fixed here: `$client->getLastError()` never works

Noticed while working out why `last_error` was always empty in my debugging output. Not touched in this PR, but it looks like something you'd want to know about.

The same pattern appears in three places — `Mail::fetchMessage()`, the connection test in `Mail.php`, and `FetchEmails.php`:

```php
$last_error = '';
if (method_exists($client, 'getLastError')) {
    $last_error = $client->getLastError();
}

if ($last_error && stristr($last_error, 'The specified charset is not supported')) {
    // Solution for MS mailboxes.
    // https://github.com/freescout-helpdesk/freescout/issues/176
    ...
    if (count($client->getErrors()) > 1) {
```

`Webklex\PHPIMAP\Client` has neither `getLastError()` nor `getErrors()`, and no `__call()`. So `method_exists()` is always false, `$last_error` can only ever stay `''`, and the branch below is never entered. Nothing crashes only because the code is unreachable — if `getLastError()` were ever added to `Client`, the `getErrors()` call on the next lines would immediately fail with "Call to undefined method".

This dates back to 2018, when the library was `webklex/laravel-imap` 1.2.7, whose `Client` wrapped the PHP `imap_*` extension and did expose both methods. They disappeared in the move to `webklex/php-imap`, and the `method_exists()` guard silently switched the branch off instead of raising anything.

The practical consequence is that **the MS mailbox charset workaround from #176 has been inert ever since** — in the connection test, in `fetchMessage()` and during normal fetching alike.

`FetchEmails.php` is a partial exception: there `$last_error` can also come from the `catch` block, so the branch is reachable in principle. But only `LegacyProtocol` ever produced the "The specified charset is not supported" message, and FreeScout never selects `legacy-imap` (`Mailbox::$in_protocols` offers only `imap` and `pop3`), so in practice it is dead too.

I left all of this alone — fixing #176 properly needs an MS mailbox to test against, which I don't have. Change (1) is arguably the modern replacement for what this code was meant to do, just sourced from `ImapProtocol::getLastError()`, which actually exists.

### Performance

Measured on the Yandex mailbox from the report, opening "Show Original" on two different threads:

| | before | after |
|---|---|---|
| thread A (143 messages that day) | 15.9 s | ~7.3 s |
| thread B (21 messages that day) | 11.1 s | ~5.8 s |

("before" is the first version of the fallback, which used `Query::get()`; both figures cover the whole lookup.)

What remains is server latency, split roughly as: date `SEARCH` 2.1–3.1 s, the first header `FETCH` 1.5–2.5 s, `getMessageByUid()` ~0.2–0.3 s, Message-ID matching in PHP 0 ms.

One measurement worth passing on, because it is counter-intuitive and it stopped me from "optimising" the wrong thing. The cost is **per command, not per byte**, and it drops sharply after the first couple of commands on a folder. In a single session:

```
fetch INTERNALDATE of 21 uids:   2564 ms,   1 KB
fetch ENVELOPE     of 21 uids:    659 ms,  11 KB
fetch RFC822.HEADER of 21 uids:    72 ms, 120 KB
```

Time is inversely proportional to volume there. So fetching less data per message — via `ENVELOPE`, or `BODY.PEEK[HEADER.FIELDS (MESSAGE-ID)]` — buys nothing, and adding commands makes things worse. (`ENVELOPE` does carry the Message-ID as its tenth element and parses fine through the existing `fetch()`, if that's ever useful elsewhere.) The remaining seconds would only go away by not searching at all, which would mean remembering each message's IMAP UID at fetch time — out of scope here.

### Testing

Verified against the `imap.yandex.ru` mailbox from the report. The Message-ID search still returns `NO [UNAVAILABLE] ... Backend error` there — the fallback is what finds the message, and "Show Original" now shows the full original instead of the truncated copy.

Happy to adjust the default scan limit, the chunk size, the width of the date windows, or the log wording.

https://github.com/freescout-help-desk/freescout/issues/5631